### PR TITLE
build: include html, xml coverage output

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,9 @@ omit =
     *admin.py
     *static*
     *templates*
+
+[html]
+directory = build/coverage/html
+
+[xml]
+output = build/coverage/coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: tox
 
       - name: Run coverage
-        if: matrix.python-version == '3.8' && matrix.toxenv == 'quality'
+        if: matrix.python-version == '3.8' && matrix.toxenv == 'py38'
         uses: codecov/codecov-action@v3
         with:
           flags: unittests

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,6 @@ coverage:
     patch:
       default:
         enabled: yes
-        target: 100%
+        target: 75%
 
 comment: false


### PR DESCRIPTION
**Description:**
Our quality checks have been failing, because we have been running the codecov step when `toxenv == 'quality'`, which is not right - we want coverage to run on _tests_, not _quality_..  This PR adds that to our ci config, updates our coverage configuration to produce a `coverage.xml` file, and also changes our coverage target to 75% (where it's at currently).