### PR TITLE
feat: step 1 of setting up an API: Setup swagger docs.

### DIFF
--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -35,12 +35,12 @@ INSTALLED_APPS = (
 THIRD_PARTY_APPS = (
     'corsheaders',
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens
+    'drf_yasg',
     # "App Permissions" compatiblity: this provides the manage_user and manage_group management commands.
     'edx_django_utils.user',
     'openedx_ledger',
     'release_util',
     'rest_framework',
-    'rest_framework_swagger',
     'social_django',
     'waffle',
 )
@@ -111,6 +111,17 @@ DATABASES = {
 
 # New DB primary keys default to an IntegerField.
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+# Django Rest Framework
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+    'PAGE_SIZE': 10,
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/

--- a/enterprise_subsidy/urls.py
+++ b/enterprise_subsidy/urls.py
@@ -21,17 +21,30 @@ from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, re_path
-from rest_framework_swagger.views import get_swagger_view
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
 
 from enterprise_subsidy.apps.api import urls as api_urls
 from enterprise_subsidy.apps.core import views as core_views
 
 admin.autodiscover()
 
+schema_view = get_schema_view(
+   openapi.Info(
+      title="enterprise-subsidy API",
+      default_version='v1',
+      description="enterprise-subsidy API Docs",
+   ),
+   public=False,
+   permission_classes=[permissions.AllowAny],
+)
+
 urlpatterns = oauth2_urlpatterns + [
     re_path(r'^admin/', admin.site.urls),
     re_path(r'^api/', include(api_urls)),
-    re_path(r'^api-docs/', get_swagger_view(title='enterprise-subsidy API')),
+    re_path(r'^api-docs(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    re_path(r'^api-docs/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     re_path(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     re_path(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
     re_path(r'^health/$', core_views.health, name='health'),

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,10 +5,10 @@ Django         # Web application framework
 djangoql
 django-cors-headers
 django-extensions
-django-rest-swagger
 django-simple-history
 django-waffle
 djangorestframework
+drf_yasg
 edx-auth-backends
 edx-django-utils
 edx-django-release-util

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,12 +21,12 @@ charset-normalizer==3.0.1
 click==8.1.3
     # via edx-django-utils
 coreapi==2.3.3
-    # via
-    #   django-rest-swagger
-    #   openapi-codec
+    # via drf-yasg
 coreschema==0.0.4
-    # via coreapi
-cryptography==39.0.0
+    # via
+    #   coreapi
+    #   drf-yasg
+cryptography==39.0.1
     # via
     #   pyjwt
     #   social-auth-core
@@ -45,6 +45,7 @@ django==3.2.17
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
@@ -67,8 +68,6 @@ django-filter==22.1
     # via openedx-ledger
 django-model-utils==4.3.1
     # via edx-rbac
-django-rest-swagger==2.2.0
-    # via -r requirements/base.in
 django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -86,11 +85,13 @@ djangoql==0.17.1
 djangorestframework==3.14.0
     # via
     #   -r requirements/base.in
-    #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
     #   edx-drf-extensions
 drf-jwt==1.19.2
     # via edx-drf-extensions
+drf-yasg==1.21.5
+    # via -r requirements/base.in
 edx-auth-backends==4.1.0
     # via -r requirements/base.in
 edx-django-release-util==1.2.0
@@ -123,6 +124,8 @@ future==0.18.3
     # via pyjwkest
 idna==3.4
     # via requests
+inflection==0.5.1
+    # via drf-yasg
 itypes==1.2.0
     # via coreapi
 jinja2==3.1.2
@@ -143,14 +146,14 @@ oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via django-rest-swagger
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
 openedx-ledger==0.1.1
     # via -r requirements/base.in
+packaging==23.0
+    # via drf-yasg
 pbr==5.11.1
     # via stevedore
 ply==3.11
@@ -183,10 +186,11 @@ pytz==2022.7.1
     #   -r requirements/base.in
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   openedx-ledger
 pyyaml==6.0
     # via edx-django-release-util
-redis==4.4.2
+redis==4.5.1
     # via openedx-ledger
 requests==2.28.2
     # via
@@ -199,14 +203,16 @@ requests==2.28.2
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
+ruamel-yaml==0.17.21
+    # via drf-yasg
+ruamel-yaml-clib==0.2.7
+    # via ruamel-yaml
 rules==3.3
     # via
     #   -r requirements/base.in
     #   openedx-ledger
 semantic-version==2.10.0
     # via edx-drf-extensions
-simplejson==3.18.1
-    # via django-rest-swagger
 six==1.16.0
     # via
     #   edx-auth-backends
@@ -230,6 +236,8 @@ stevedore==4.1.1
     #   edx-django-utils
     #   edx-opaque-keys
 uritemplate==4.1.1
-    # via coreapi
+    # via
+    #   coreapi
+    #   drf-yasg
 urllib3==1.26.14
     # via requests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -22,7 +22,7 @@ idna==3.4
     # via requests
 packaging==23.0
     # via tox
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -43,5 +43,5 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 urllib3==1.26.14
     # via requests
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -65,17 +65,17 @@ code-annotations==1.3.0
 coreapi==2.3.3
     # via
     #   -r requirements/validation.txt
-    #   django-rest-swagger
-    #   openapi-codec
+    #   drf-yasg
 coreschema==0.0.4
     # via
     #   -r requirements/validation.txt
     #   coreapi
+    #   drf-yasg
 coverage[toml]==7.1.0
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/validation.txt
     #   pyjwt
@@ -107,6 +107,7 @@ django==3.2.17
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
@@ -139,8 +140,6 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
-django-rest-swagger==2.2.0
-    # via -r requirements/validation.txt
 django-simple-history==3.0.0
     # via
     #   -r requirements/validation.txt
@@ -157,8 +156,8 @@ djangoql==0.17.1
 djangorestframework==3.14.0
     # via
     #   -r requirements/validation.txt
-    #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
     #   edx-drf-extensions
 docutils==0.19
     # via
@@ -168,6 +167,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
+drf-yasg==1.21.5
+    # via -r requirements/validation.txt
 edx-auth-backends==4.1.0
     # via -r requirements/validation.txt
 edx-django-release-util==1.2.0
@@ -229,6 +230,10 @@ importlib-resources==5.10.2
     # via
     #   -r requirements/validation.txt
     #   keyring
+inflection==0.5.1
+    # via
+    #   -r requirements/validation.txt
+    #   drf-yasg
 iniconfig==2.0.0
     # via
     #   -r requirements/validation.txt
@@ -303,11 +308,7 @@ oauthlib==3.2.2
     #   -r requirements/validation.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/validation.txt
-    #   django-rest-swagger
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
@@ -318,6 +319,7 @@ packaging==23.0
     #   -r requirements/pip-tools.txt
     #   -r requirements/validation.txt
     #   build
+    #   drf-yasg
     #   pytest
     #   tox
 path==16.6.0
@@ -332,7 +334,7 @@ pkginfo==1.9.6
     # via
     #   -r requirements/validation.txt
     #   twine
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -387,7 +389,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.16.0
+pylint==2.16.1
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -445,6 +447,7 @@ pytz==2022.7.1
     #   -r requirements/validation.txt
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   openedx-ledger
 pyyaml==6.0
     # via
@@ -456,7 +459,7 @@ readme-renderer==37.3
     # via
     #   -r requirements/validation.txt
     #   twine
-redis==4.4.2
+redis==4.5.1
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
@@ -488,6 +491,14 @@ rich==13.3.1
     # via
     #   -r requirements/validation.txt
     #   twine
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/validation.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.7
+    # via
+    #   -r requirements/validation.txt
+    #   ruamel-yaml
 rules==3.3
     # via
     #   -r requirements/validation.txt
@@ -500,10 +511,6 @@ semantic-version==2.10.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-simplejson==3.18.1
-    # via
-    #   -r requirements/validation.txt
-    #   django-rest-swagger
 six==1.16.0
     # via
     #   -r requirements/validation.txt
@@ -577,12 +584,13 @@ uritemplate==4.1.1
     # via
     #   -r requirements/validation.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.14
     # via
     #   -r requirements/validation.txt
     #   requests
     #   twine
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -598,7 +606,7 @@ wrapt==1.14.1
     # via
     #   -r requirements/validation.txt
     #   astroid
-zipp==3.12.0
+zipp==3.13.0
     # via
     #   -r requirements/validation.txt
     #   importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -61,17 +61,17 @@ code-annotations==1.3.0
 coreapi==2.3.3
     # via
     #   -r requirements/test.txt
-    #   django-rest-swagger
-    #   openapi-codec
+    #   drf-yasg
 coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-yasg
 coverage[toml]==7.1.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -101,6 +101,7 @@ django==3.2.17
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
@@ -130,8 +131,6 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-django-rest-swagger==2.2.0
-    # via -r requirements/test.txt
 django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -149,8 +148,8 @@ djangoql==0.17.1
 djangorestframework==3.14.0
     # via
     #   -r requirements/test.txt
-    #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
     #   edx-drf-extensions
 doc8==1.1.1
     # via -r requirements/doc.in
@@ -164,6 +163,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-yasg==1.21.5
+    # via -r requirements/test.txt
 edx-auth-backends==4.1.0
     # via -r requirements/test.txt
 edx-django-release-util==1.2.0
@@ -225,6 +226,10 @@ importlib-metadata==6.0.0
     #   twine
 importlib-resources==5.10.2
     # via keyring
+inflection==0.5.1
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
 iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
@@ -288,11 +293,7 @@ oauthlib==3.2.2
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/test.txt
-    #   django-rest-swagger
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -302,6 +303,7 @@ packaging==23.0
     # via
     #   -r requirements/test.txt
     #   build
+    #   drf-yasg
     #   pytest
     #   sphinx
     #   tox
@@ -311,7 +313,7 @@ pbr==5.11.1
     #   stevedore
 pkginfo==1.9.6
     # via twine
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -359,7 +361,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.16.0
+pylint==2.16.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -416,6 +418,7 @@ pytz==2022.7.1
     #   babel
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   openedx-ledger
 pyyaml==6.0
     # via
@@ -424,7 +427,7 @@ pyyaml==6.0
     #   edx-django-release-util
 readme-renderer==37.3
     # via twine
-redis==4.4.2
+redis==4.5.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -453,6 +456,14 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.1
     # via twine
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.7
+    # via
+    #   -r requirements/test.txt
+    #   ruamel-yaml
 rules==3.3
     # via
     #   -r requirements/test.txt
@@ -463,10 +474,6 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.18.1
-    # via
-    #   -r requirements/test.txt
-    #   django-rest-swagger
 six==1.16.0
     # via
     #   -r requirements/test.txt
@@ -558,12 +565,13 @@ uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.14
     # via
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -573,7 +581,7 @@ wrapt==1.14.1
     # via
     #   -r requirements/test.txt
     #   astroid
-zipp==3.12.0
+zipp==3.13.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.38.4
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0
     # via -r requirements/pip.in
-setuptools==67.1.0
+setuptools==67.2.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -36,13 +36,13 @@ click==8.1.3
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
-    #   django-rest-swagger
-    #   openapi-codec
+    #   drf-yasg
 coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-cryptography==39.0.0
+    #   drf-yasg
+cryptography==39.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -62,6 +62,7 @@ django==3.2.17
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
@@ -89,8 +90,6 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-django-rest-swagger==2.2.0
-    # via -r requirements/base.txt
 django-simple-history==3.0.0
     # via
     #   -r requirements/base.txt
@@ -107,13 +106,15 @@ djangoql==0.17.1
 djangorestframework==3.14.0
     # via
     #   -r requirements/base.txt
-    #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
     #   edx-drf-extensions
 drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+drf-yasg==1.21.5
+    # via -r requirements/base.txt
 edx-auth-backends==4.1.0
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
@@ -159,6 +160,10 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
+inflection==0.5.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 itypes==1.2.0
     # via
     #   -r requirements/base.txt
@@ -189,16 +194,16 @@ oauthlib==3.2.2
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/base.txt
-    #   django-rest-swagger
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
 openedx-ledger==0.1.1
     # via -r requirements/base.txt
+packaging==23.0
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 pbr==5.11.1
     # via
     #   -r requirements/base.txt
@@ -254,13 +259,14 @@ pytz==2022.7.1
     #   -r requirements/base.txt
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   openedx-ledger
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   edx-django-release-util
-redis==4.4.2
+redis==4.5.1
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -278,6 +284,14 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.7
+    # via
+    #   -r requirements/base.txt
+    #   ruamel-yaml
 rules==3.3
     # via
     #   -r requirements/base.txt
@@ -286,10 +300,6 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.18.1
-    # via
-    #   -r requirements/base.txt
-    #   django-rest-swagger
 six==1.16.0
     # via
     #   -r requirements/base.txt
@@ -326,6 +336,7 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.14
     # via
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -55,17 +55,17 @@ code-annotations==1.3.0
 coreapi==2.3.3
     # via
     #   -r requirements/test.txt
-    #   django-rest-swagger
-    #   openapi-codec
+    #   drf-yasg
 coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-yasg
 coverage[toml]==7.1.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -95,6 +95,7 @@ django==3.2.17
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
@@ -124,8 +125,6 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-django-rest-swagger==2.2.0
-    # via -r requirements/test.txt
 django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -143,8 +142,8 @@ djangoql==0.17.1
 djangorestframework==3.14.0
     # via
     #   -r requirements/test.txt
-    #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
     #   edx-drf-extensions
 docutils==0.19
     # via readme-renderer
@@ -152,6 +151,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-yasg==1.21.5
+    # via -r requirements/test.txt
 edx-auth-backends==4.1.0
     # via -r requirements/test.txt
 edx-django-release-util==1.2.0
@@ -210,6 +211,10 @@ importlib-metadata==6.0.0
     #   twine
 importlib-resources==5.10.2
     # via keyring
+inflection==0.5.1
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
 iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
@@ -273,11 +278,7 @@ oauthlib==3.2.2
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/test.txt
-    #   django-rest-swagger
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -286,6 +287,7 @@ openedx-ledger==0.1.1
 packaging==23.0
     # via
     #   -r requirements/test.txt
+    #   drf-yasg
     #   pytest
     #   tox
 pbr==5.11.1
@@ -294,7 +296,7 @@ pbr==5.11.1
     #   stevedore
 pkginfo==1.9.6
     # via twine
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -344,7 +346,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.16.0
+pylint==2.16.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -398,6 +400,7 @@ pytz==2022.7.1
     #   -r requirements/test.txt
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   openedx-ledger
 pyyaml==6.0
     # via
@@ -406,7 +409,7 @@ pyyaml==6.0
     #   edx-django-release-util
 readme-renderer==37.3
     # via twine
-redis==4.4.2
+redis==4.5.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -432,6 +435,14 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.1
     # via twine
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.7
+    # via
+    #   -r requirements/test.txt
+    #   ruamel-yaml
 rules==3.3
     # via
     #   -r requirements/test.txt
@@ -442,10 +453,6 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.18.1
-    # via
-    #   -r requirements/test.txt
-    #   django-rest-swagger
 six==1.16.0
     # via
     #   -r requirements/test.txt
@@ -515,12 +522,13 @@ uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.14
     # via
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -530,7 +538,7 @@ wrapt==1.14.1
     # via
     #   -r requirements/test.txt
     #   astroid
-zipp==3.12.0
+zipp==3.13.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -50,17 +50,17 @@ code-annotations==1.3.0
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
-    #   django-rest-swagger
-    #   openapi-codec
+    #   drf-yasg
 coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
+    #   drf-yasg
 coverage[toml]==7.1.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -84,6 +84,7 @@ distlib==0.3.6
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
@@ -113,8 +114,6 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-django-rest-swagger==2.2.0
-    # via -r requirements/base.txt
 django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -132,13 +131,15 @@ djangoql==0.17.1
 djangorestframework==3.14.0
     # via
     #   -r requirements/base.txt
-    #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
     #   edx-drf-extensions
 drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+drf-yasg==1.21.5
+    # via -r requirements/base.txt
 edx-auth-backends==4.1.0
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
@@ -186,6 +187,10 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
+inflection==0.5.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 iniconfig==2.0.0
     # via pytest
 isort==5.12.0
@@ -226,11 +231,7 @@ oauthlib==3.2.2
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/base.txt
-    #   django-rest-swagger
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -238,13 +239,15 @@ openedx-ledger==0.1.1
     # via -r requirements/base.txt
 packaging==23.0
     # via
+    #   -r requirements/base.txt
+    #   drf-yasg
     #   pytest
     #   tox
 pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   pylint
     #   virtualenv
@@ -282,7 +285,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.16.0
+pylint==2.16.1
     # via
     #   edx-lint
     #   pylint-celery
@@ -327,13 +330,14 @@ pytz==2022.7.1
     #   -r requirements/base.txt
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   openedx-ledger
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-release-util
-redis==4.4.2
+redis==4.5.1
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -351,6 +355,14 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.7
+    # via
+    #   -r requirements/base.txt
+    #   ruamel-yaml
 rules==3.3
     # via
     #   -r requirements/base.txt
@@ -359,10 +371,6 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.18.1
-    # via
-    #   -r requirements/base.txt
-    #   django-rest-swagger
 six==1.16.0
     # via
     #   -r requirements/base.txt
@@ -420,11 +428,12 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.14
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via tox
 wrapt==1.14.1
     # via astroid

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -68,19 +68,19 @@ coreapi==2.3.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   django-rest-swagger
-    #   openapi-codec
+    #   drf-yasg
 coreschema==0.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-yasg
 coverage[toml]==7.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -114,6 +114,7 @@ django==3.2.17
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
@@ -151,10 +152,6 @@ django-model-utils==4.3.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-rbac
-django-rest-swagger==2.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
 django-simple-history==3.0.0
     # via
     #   -r requirements/quality.txt
@@ -175,8 +172,8 @@ djangorestframework==3.14.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
     #   edx-drf-extensions
 docutils==0.19
     # via
@@ -187,6 +184,10 @@ drf-jwt==1.19.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-yasg==1.21.5
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 edx-auth-backends==4.1.0
     # via
     #   -r requirements/quality.txt
@@ -262,6 +263,11 @@ importlib-resources==5.10.2
     # via
     #   -r requirements/quality.txt
     #   keyring
+inflection==0.5.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   drf-yasg
 iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
@@ -348,12 +354,7 @@ oauthlib==3.2.2
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   django-rest-swagger
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -366,6 +367,7 @@ packaging==23.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   drf-yasg
     #   pytest
     #   tox
 pbr==5.11.1
@@ -377,7 +379,7 @@ pkginfo==1.9.6
     # via
     #   -r requirements/quality.txt
     #   twine
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -437,7 +439,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.16.0
+pylint==2.16.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -506,6 +508,7 @@ pytz==2022.7.1
     #   -r requirements/test.txt
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   openedx-ledger
 pyyaml==6.0
     # via
@@ -517,7 +520,7 @@ readme-renderer==37.3
     # via
     #   -r requirements/quality.txt
     #   twine
-redis==4.4.2
+redis==4.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -552,6 +555,16 @@ rich==13.3.1
     # via
     #   -r requirements/quality.txt
     #   twine
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.7
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   ruamel-yaml
 rules==3.3
     # via
     #   -r requirements/quality.txt
@@ -566,11 +579,6 @@ semantic-version==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.18.1
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   django-rest-swagger
 six==1.16.0
     # via
     #   -r requirements/quality.txt
@@ -653,13 +661,14 @@ uritemplate==4.1.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.14
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -673,7 +682,7 @@ wrapt==1.14.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-zipp==3.12.0
+zipp==3.13.0
     # via
     #   -r requirements/quality.txt
     #   importlib-metadata


### PR DESCRIPTION
django-rest-swagger is deprecated, so first I have to change to drf-yasg.  This also fixes the /api-docs/ page which previously used an outdated template which imported other non-existent templates due to django-rest-swagger no longer being maintained.

ENT-6620