### PR TITLE
fix: use mysql8 in docker-compose.yml and ensure social auth key/secret are correct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ enterprise_subsidy/conf/locale/messages.mo
 .mr.developer.cfg
 .project
 .pydevproject
+.vscode
 
 # QA
 coverage.xml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   db:
-    image: mysql:5.6
+    image: mysql:8.0.28-oracle
     container_name: enterprise_subsidy.db
     environment:
       MYSQL_ROOT_PASSWORD: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   db:
-    image: mysql:8.0.28-oracle
+    image: edxops/mysql:5.7
     container_name: enterprise_subsidy.db
     environment:
       MYSQL_ROOT_PASSWORD: ""
@@ -9,7 +9,7 @@ services:
     networks:
       - devstack_default
     volumes:
-      - enterprise_subsidy_mysql:/var/lib/mysql
+      - enterprise_subsidy_mysql57:/var/lib/mysql
 
   memcache:
     image: memcached:1.4.24
@@ -41,4 +41,4 @@ networks:
     external: true
 
 volumes:
-  enterprise_subsidy_mysql:
+  enterprise_subsidy_mysql57:

--- a/enterprise_subsidy/settings/devstack.py
+++ b/enterprise_subsidy/settings/devstack.py
@@ -17,8 +17,8 @@ DATABASES = {
 OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
 
 # OAuth2 variables specific to social-auth/SSO login use case.
-SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'enterprise_subsidy-sso-key')
-SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'enterprise_subsidy-sso-secret')
+SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'enterprise-subsidy-sso-key')
+SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'enterprise-subsidy-sso-secret')
 SOCIAL_AUTH_EDX_OAUTH2_ISSUER = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_ISSUER', 'http://localhost:18000')
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT', 'http://edx.devstack.lms:18000')
 SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL', 'http://localhost:18000/logout')


### PR DESCRIPTION
**Description:** 

Attempting to run enterprise-subsidy on my M1 Apple Silicon machine did not work:

```shell
❯ make dev.up
docker-compose up -d
Creating network "enterprise-subsidy_default" with the default driver
Creating volume "enterprise-subsidy_enterprise_subsidy_mysql" with default driver
Pulling db (mysql:5.6)...
5.6: Pulling from library/mysql
ERROR: no matching manifest for linux/arm64/v8 in the manifest list entries
make: *** [dev.up] Error 1
```

Following the fix in other IDAs, I bumped the MySQL version in docker-compose.yml to MySQL8.

Secondarily, when trying to authenticate with enterprise-subsidy for the first time, I got redirected to an error in the LMS with a "invalid client id" warning. There is a mismatch between the client ids in the generated OAuth applications and the `SOCIAL_AUTH_EDX_OAUTH2_KEY` / `SOCIAL_AUTH_EDX_OAUTH2_SECRET` devstack variables.

Ensuring these match in the devstack settings and in the LMS DB made authentication work with `enterprise-subsidy`.

<img width="1451" alt="image" src="https://user-images.githubusercontent.com/2828721/220911002-56923162-ef9a-4a7d-91a6-168c34db5267.png">

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Attempt to run / provision the `enterprise-subsidy` IDA on an M1 Apple Silicon machine.
2. Expect it to to run and authenticate properly.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
