### PR TITLE
feat: connect POST /api/v1/transactions/ to redeem()

### DIFF
--- a/docs/decisions/0002-initial-api-specification.rst
+++ b/docs/decisions/0002-initial-api-specification.rst
@@ -160,8 +160,8 @@ Inputs
 - ``subsidy-uuid`` (URL path, required): The uuid (primary key) of the subsidy for which transactions should be listed.
 - ``include_aggregates`` (query param, optional): Specifies if aggregates (quantities, number of transactions) should be
   returned as part of the paginated response.  Defaults to ``true``.
-- ``user_id`` (query param, optional): If present, filters returned transactions and/or aggregates to only
-  those associated with the specified ``user_id`` value.
+- ``learner_id`` (query param, optional): If present, filters returned transactions and/or aggregates to only
+  those associated with the specified ``learner_id`` value.
 - ``content_key`` (query param, optional): If present, filters returned transactions and/or aggregates to only
   those associated with the specified ``content_key`` value.
 
@@ -185,7 +185,7 @@ Returns a paginated list of aggregate and transaction data:
                'uuid': 'the-transaction-uuid',
                'status': 'completed',  TODO: enumerate valid statuses
                'idempotency_key': 'the-idempotency-key',
-               'user_id': 54321,
+               'learner_id': 54321,
                'content_key': 'demox_1234+2T2023',
                'quantity': 19900,
                'unit': 'USD_CENTS',
@@ -237,7 +237,7 @@ Returns a single transaction object (or 404 if no such transaction exists).
        'uuid': 'the-transaction-uuid',
        'status': 'completed',  TODO: enumerate valid statuses
        'idempotency_key': 'the-idempotency-key',
-       'user_id': 54321,
+       'learner_id': 54321,
        'content_key': 'demox_1234+2T2023',
        'quantity': 19900,
        'unit': 'USD_CENTS',
@@ -254,7 +254,7 @@ Permissions
 -----------
 
 enterprise_learner
-  The transaction object should only be returned if requesting user's ``lms_user_id`` matches the ``user_id``
+  The transaction object should only be returned if requesting user's ``lms_user_id`` matches the ``learner_id``
   for the transaction record.
 
 enterprise_admin
@@ -267,7 +267,7 @@ openedx_operator
 
 POST enterprise subsidy transaction
 ===================================
-**/api/v1/subsidies/[subsidy-uuid]/transactions/**
+**/api/v1/transactions/**
 
 Create a new subsidy transaction in the subsidy's ledger.
 Only service users (those with ``openedx_operator`` role assignment) can do this.
@@ -279,32 +279,33 @@ on the course-discovery service for this data.
 Inputs
 ------
 
-- ``subsidy-uuid`` (URL path, required): The uuid (primary key) of the subsidy for which transactions should be listed.
-- ``user_id`` (POST data, required): The user for whom the transaction is written and for which a fulfillment should occur.
+- ``subsidy_uuid`` (POST data, required): The uuid (primary key) of the subsidy for which transactions should be created.
+- ``learner_id`` (POST data, required): The user for whom the transaction is written and for which a fulfillment should occur.
 - ``content_key`` (POST data, required): The content for which a fulfillment is created.
-- ``access_policy_uuid`` (POST data, required): The uuid of the policy that allowed the ledger transaction to be created.
+- ``subsidy_access_policy_uuid`` (POST data, required):
+      The uuid of the policy that allowed the ledger transaction to be created.
 
 Outputs
 -------
 Returns data about the transaction.
 
-::
+.. code-block:: json
 
    {
-       'uuid': 'the-transaction-uuid',
-       'status': 'completed',
-       'idempotency_key': 'the-idempotency-key',
-       'user_id': 54321,
-       'content_key': 'demox_1234+2T2023',
-       'quantity': 19900,
-       'unit': 'USD_CENTS',
-       'reference_id': 1234,
-       'reference_table': 'enrollments',
-       'subsidy_access_policy_uuid': 'a-policy-uuid',
-       'metadata': {...},
-       'created': 'created-datetime',
-       'modified': 'modified-datetime',
-       'reversals': []
+       "uuid": "the-transaction-uuid",
+       "state": "committed",
+       "idempotency_key": "the-idempotency-key",
+       "learner_id": 54321,
+       "content_key": "demox_1234+2T2023",
+       "quantity": 19900,
+       "unit": "USD_CENTS",
+       "reference_id": 1234,
+       "reference_type": "PlaceholderOCMEnrollmentReferenceType",
+       "subsidy_access_policy_uuid": "a-policy-uuid",
+       "metadata": {...},
+       "created": "created-datetime",
+       "modified": "modified-datetime",
+       "reversals": []
    }
 
 Permissions
@@ -346,7 +347,7 @@ Returns data about the transaction and its reversals.
        'uuid': 'the-transaction-uuid',
        'status': 'completed',
        'idempotency_key': 'the-idempotency-key',
-       'user_id': 54321,
+       'learner_id': 54321,
        'content_key': 'demox_1234+2T2023',
        'quantity': 19900,
        'unit': 'USD_CENTS',
@@ -392,7 +393,7 @@ Inputs
 ------
 
 - ``subsidy-uuid`` (URL path, required): The uuid (primary key) of the subsidy for which transactions should be listed.
-- ``user_id`` (POST data, required): The user to whom the query pertains.
+- ``learner_id`` (POST data, required): The user to whom the query pertains.
 - ``content_key`` (POST data, required): The content to which the query pertains.
 
 Outputs

--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -2,7 +2,7 @@
 Serializers for the enterprise-subsidy API.
 """
 
-from openedx_ledger.models import Transaction
+from openedx_ledger.models import Reversal, Transaction
 from rest_framework import serializers
 
 from enterprise_subsidy.apps.subsidy.models import Subsidy
@@ -10,7 +10,7 @@ from enterprise_subsidy.apps.subsidy.models import Subsidy
 
 class SubsidySerializer(serializers.ModelSerializer):
     """
-    Serializer for the `SubscriptionPlan` model.
+    Serializer for the `Subsidy` model.
     """
     class Meta:
         """
@@ -32,13 +32,41 @@ class SubsidySerializer(serializers.ModelSerializer):
         ]
 
 
-class TransactionSerializer(serializers.ModelSerializer):
+class ReversalSerializer(serializers.ModelSerializer):
     """
-    Serializer for the `SubscriptionPlan` model.
+    Serializer for the `Reversal` model.
     """
+
     class Meta:
         """
-        Meta class for SubsidySerializer.
+        Meta class for ReversalSerializer.
+        """
+        model = Reversal
+        fields = [
+            "uuid",
+            "state",
+            "idempotency_key",
+            "quantity",
+            "metadata",
+            "created",
+            "modified",
+        ]
+
+
+class TransactionSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the `Transaction` model.
+
+    When using this serializer on a queryset, it can help with performance to prefectch the following:
+
+      .prefectch_related("ledger__unit", "reversal")
+    """
+    unit = serializers.SerializerMethodField()
+    reversal = ReversalSerializer(read_only=True)
+
+    class Meta:
+        """
+        Meta class for TransactionSerializer.
         """
         model = Transaction
         fields = [
@@ -48,13 +76,21 @@ class TransactionSerializer(serializers.ModelSerializer):
             "lms_user_id",
             "content_key",
             "quantity",
+            "unit",  # Manually fetch from parent ledger via get_unit().
             "reference_id",
             "reference_type",
             "subsidy_access_policy_uuid",
             "metadata",
             "created",
             "modified",
-            # TODO: serialize derived fields:
-            # "unit",  # Get from parent ledger.
-            # "reversals",  # Calculate by querying reversals.
+            "reversal",  # Note that the `reversal` field is found via reverse relationship.
         ]
+
+    def get_unit(self, obj):
+        """
+        Simply fetch the unit slug from the parent Ledger.
+
+        Returns:
+            str: unit slug.
+        """
+        return obj.ledger.unit if obj.ledger else None

--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -1,0 +1,171 @@
+"""
+Tests for views.
+"""
+import json
+import uuid
+
+import ddt
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from enterprise_subsidy.apps.api.v1.tests.mixins import APITestMixin
+from enterprise_subsidy.apps.subsidy.tests.factories import SubsidyFactory
+
+
+class APITestBase(APITestMixin):
+    """
+    Provides shared test resource setup between curation-related API test classes.
+
+    Contains boilerplate to create a couple of subsidies with related ledgers and starting transactions.
+    """
+    def setUp(self):
+        super().setUp()
+
+        # Create the main test objects that the test users should be able to access.
+        self.subsidy_one = SubsidyFactory(enterprise_customer_uuid=self.enterprise_uuid, starting_balance=10000)
+        self.ledger_one = self.subsidy_one.ledger
+        self.transaction_one = self.subsidy_one.initialize_ledger()
+
+        # Create an extra subsidy corresponding to a different enterprise customer an unprivileged default test user
+        # should not be able to access.
+        self.subsidy_two = SubsidyFactory(enterprise_customer_uuid=uuid.uuid4(), starting_balance=10000)
+        self.ledger_two = self.subsidy_two.ledger
+        self.transaction_two = self.subsidy_two.initialize_ledger()
+
+
+@ddt.ddt
+class TransactionViewSetTests(APITestBase):
+    """
+    Test TransactionViewSet.
+    """
+
+    # Uncomment this later once we have segment events firing.
+    # @mock.patch('enterprise_subsidy.apps.api.v1.event_utils.track_event')
+    # def test_create(self, mock_track_event):
+    def test_create(self):
+        """
+        Test create Transaction, happy case.
+        """
+        url = reverse("api:v1:transaction-list")
+        # Create privileged staff user that should be able to create Transactions.
+        self.set_up_operator()
+        post_data = {
+            "subsidy_uuid": str(self.subsidy_one.uuid),
+            "learner_id": 1234,
+            "content_key": "course-v1:edX-test-course",
+            "access_policy_uuid": str(uuid.uuid4()),
+        }
+        response = self.client.post(url, post_data)
+        assert response.status_code == status.HTTP_201_CREATED
+        create_response_data = response.json()
+        assert len(create_response_data["uuid"]) == 36
+        assert create_response_data["idempotency_key"]  # TODO: fix this once the idempotency key format is finalized.
+        assert create_response_data["content_key"] == post_data["content_key"]
+        assert create_response_data["lms_user_id"] == post_data["learner_id"]
+        assert create_response_data["subsidy_access_policy_uuid"] == post_data["access_policy_uuid"]
+        assert json.loads(create_response_data["metadata"]) == {}
+        assert create_response_data["unit"] == self.ledger_one.unit
+        assert create_response_data["quantity"] < 0  # No need to be exact at this time, I'm just testing create works.
+        assert create_response_data["reference_id"]  # Ditto ^
+        assert create_response_data["reference_type"]  # Ditto ^
+        assert create_response_data["reversal"] is None
+        assert create_response_data["state"] == "committed"
+
+        # `create` was successful, so now call `retreive` to read the new Transaction and do a basic smoke test.
+        detail_url = reverse("api:v1:transaction-detail", kwargs={"uuid": create_response_data["uuid"]})
+        retrieve_response = self.client.get(detail_url)
+        assert retrieve_response.status_code == status.HTTP_200_OK
+        retrieve_response_data = retrieve_response.json()
+        assert retrieve_response_data["uuid"] == create_response_data["uuid"]
+        assert retrieve_response_data["idempotency_key"] == create_response_data["idempotency_key"]
+
+        # Uncomment after Segment events are setup:
+        #
+        # Finally, check that a tracking event was emitted:
+        # mock_track_event.assert_called_once_with(
+        #     STATIC_LMS_USER_ID,
+        #     SegmentEvents.TRANSACTION_CREATED,
+        #     {
+        #         "ledger_transaction_uuid": create_response_data["uuid"],
+        #         "enterprise_customer_uuid": str(self.subsidy_one.enterprise_customer_uuid),
+        #         "subsidy_uuid": str(self.curation_config_one.uuid),
+        #     },
+        # )
+
+    @ddt.data("admin", "learner")
+    def test_create_denied_role(self, role):
+        """
+        Test create Transaction, permission denied due to not being an operator.
+        """
+        if role == "admin":
+            self.set_up_admin()
+        elif role == "learner":
+            self.set_up_learner()
+        url = reverse("api:v1:transaction-list")
+        post_data = {
+            "subsidy_uuid": str(self.subsidy_one.uuid),
+            "learner_id": 1234,
+            "content_key": "course-v1:edX-test-course",
+            "access_policy_uuid": str(uuid.uuid4()),
+        }
+        response = self.client.post(url, post_data)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        # Just make sure there's any parseable json which is likely to contain an explanation of the error.
+        assert response.json()
+
+    def test_create_invalid_subsidy_uuid(self):
+        """
+        Test create Transaction, failed due to invalid uuid.
+        """
+        url = reverse("api:v1:transaction-list")
+        # Create privileged staff user that should be able to create Transactions.
+        self.set_up_operator()
+
+        post_data = {
+            "subsidy_uuid": str(self.subsidy_one.uuid) + "a",  # Make uuid invalid.
+            "learner_id": 1234,
+            "content_key": "course-v1:edX-test-course",
+            "access_policy_uuid": str(uuid.uuid4()),
+        }
+        response = self.client.post(url, post_data)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "detail" in response.json()
+
+    def test_create_invalid_access_policy_uuid(self):
+        """
+        Test create Transaction, failed due to invalid uuid.
+        """
+        url = reverse("api:v1:transaction-list")
+        # Create privileged staff user that should be able to create Transactions.
+        self.set_up_operator()
+
+        post_data = {
+            "subsidy_uuid": str(self.subsidy_one.uuid),
+            "learner_id": 1234,
+            "content_key": "course-v1:edX-test-course",
+            "access_policy_uuid": str(uuid.uuid4()) + "a",  # Make uuid invalid.
+        }
+        response = self.client.post(url, post_data)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Error" in response.json()
+
+    @ddt.data("subsidy_uuid", "learner_id", "content_key", "access_policy_uuid")
+    def test_create_missing_inputs(self, missing_post_arg):
+        """
+        Test create Transaction, 4xx due to missing inputs.
+        """
+        url = reverse("api:v1:transaction-list")
+        # Create privileged staff user that should be able to create Transactions.
+        self.set_up_operator()
+
+        post_data = {
+            "subsidy_uuid": str(self.subsidy_one.uuid),
+            "learner_id": 1234,
+            "content_key": "course-v1:edX-test-course",
+            "access_policy_uuid": str(uuid.uuid4()),
+        }
+        del post_data[missing_post_arg]
+        response = self.client.post(url, post_data)
+        assert response.status_code >= 400 and response.status_code < 500
+        # Just make sure there's any parseable json which is likely to contain an explanation of the error.
+        assert response.json()

--- a/enterprise_subsidy/apps/api/v1/urls.py
+++ b/enterprise_subsidy/apps/api/v1/urls.py
@@ -11,7 +11,7 @@ Reading, creating, and reversing Transactions::
 
   GET  /api/v1/transactions/
   GET  /api/v1/transactions/{transaction_uuid}/
-  POST /api/v1/transactions/?subsidy_uuid={subsidy_uuid}
+  POST /api/v1/transactions/
   POST /api/v1/transactions/{transaction_uuid}/reverse
 """
 from rest_framework.routers import DefaultRouter

--- a/enterprise_subsidy/apps/api/v1/views.py
+++ b/enterprise_subsidy/apps/api/v1/views.py
@@ -35,11 +35,11 @@ class SubsidyViewSet(
     """
     authentication_classes = [JwtAuthentication, SessionAuthentication]
     permission_classes = [permissions.IsAuthenticated]
-    lookup_field = 'uuid'
+    lookup_field = "uuid"
     serializer_class = SubsidySerializer
 
     # Fields that control permissions for 'list' actions, required by PermissionRequiredForListingMixin.
-    list_lookup_field = 'enterprise_customer_uuid'
+    list_lookup_field = "enterprise_customer_uuid"
     allowed_roles = [ENTERPRISE_SUBSIDY_ADMIN_ROLE, ENTERPRISE_SUBSIDY_OPERATOR_ROLE]
     role_assignment_class = EnterpriseSubsidyRoleAssignment
 
@@ -74,7 +74,7 @@ class SubsidyViewSet(
 
         For detail endpoints, the PK can simply be found in ``self.kwargs``.
         """
-        return self.kwargs.get('uuid')
+        return self.kwargs.get("uuid")
 
     @property
     def base_queryset(self):
@@ -85,18 +85,18 @@ class SubsidyViewSet(
         """
         kwargs = {}
         if self.requested_enterprise_customer_uuid:
-            kwargs.update({'enterprise_customer_uuid': self.requested_enterprise_customer_uuid})
+            kwargs.update({"enterprise_customer_uuid": self.requested_enterprise_customer_uuid})
         if self.requested_subsidy_uuid:
-            kwargs.update({'uuid': self.requested_subsidy_uuid})
+            kwargs.update({"uuid": self.requested_subsidy_uuid})
 
         return Subsidy.objects.filter(**kwargs).prefetch_related(
             # Fields used for calculating the ledger balance.
-            'ledger__transactions__state',
-            'ledger__transactions__quantity',
-            'ledger__transactions__reversal',
-            'ledger__transactions__reversal__state',
-            'ledger__transactions__reversal__quantity',
-        ).order_by('uuid')
+            "ledger__transactions__state",
+            "ledger__transactions__quantity",
+            "ledger__transactions__reversal",
+            "ledger__transactions__reversal__state",
+            "ledger__transactions__reversal__quantity",
+        ).order_by("uuid")
 
 
 class TransactionViewSet(
@@ -123,11 +123,11 @@ class TransactionViewSet(
     """
     authentication_classes = [JwtAuthentication, SessionAuthentication]
     permission_classes = [permissions.IsAuthenticated]
-    lookup_field = 'uuid'
+    lookup_field = "uuid"
     serializer_class = TransactionSerializer
 
     # Fields that control permissions for 'list' actions, required by PermissionRequiredForListingMixin.
-    list_lookup_field = 'ledger__subisidy__enterprise_customer_uuid'
+    list_lookup_field = "ledger__subisidy__enterprise_customer_uuid"
     allowed_roles = [ENTERPRISE_SUBSIDY_ADMIN_ROLE, ENTERPRISE_SUBSIDY_LEARNER_ROLE, ENTERPRISE_SUBSIDY_OPERATOR_ROLE]
     role_assignment_class = EnterpriseSubsidyRoleAssignment
 
@@ -162,7 +162,7 @@ class TransactionViewSet(
 
         For detail endpoints, the PK can simply be found in ``self.kwargs``.
         """
-        return self.kwargs.get('uuid')
+        return self.kwargs.get("uuid")
 
     @property
     def base_queryset(self):
@@ -173,8 +173,8 @@ class TransactionViewSet(
         """
         kwargs = {}
         if self.requested_enterprise_customer_uuid:
-            kwargs.update({'ledger__subsidy__enterprise_customer_uuid': self.requested_enterprise_customer_uuid})
+            kwargs.update({"ledger__subsidy__enterprise_customer_uuid": self.requested_enterprise_customer_uuid})
         if self.requested_transaction_uuid:
-            kwargs.update({'uuid': self.requested_transaction_uuid})
+            kwargs.update({"uuid": self.requested_transaction_uuid})
 
-        return Transaction.objects.filter(**kwargs).order_by('uuid')
+        return Transaction.objects.filter(**kwargs).order_by("uuid")

--- a/enterprise_subsidy/apps/api/v1/views.py
+++ b/enterprise_subsidy/apps/api/v1/views.py
@@ -1,11 +1,16 @@
 """
 Views for the enterprise-subsidy service.
 """
+import json
+import uuid
+
+from django.core.exceptions import ValidationError
 from edx_rbac.mixins import PermissionRequiredForListingMixin
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from openedx_ledger.models import Transaction
-from rest_framework import mixins, permissions, viewsets
+from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.response import Response
 
 from enterprise_subsidy.apps.api.v1 import utils
 from enterprise_subsidy.apps.api.v1.serializers import SubsidySerializer, TransactionSerializer
@@ -90,12 +95,9 @@ class SubsidyViewSet(
             kwargs.update({"uuid": self.requested_subsidy_uuid})
 
         return Subsidy.objects.filter(**kwargs).prefetch_related(
-            # Fields used for calculating the ledger balance.
-            "ledger__transactions__state",
-            "ledger__transactions__quantity",
+            # Related objects used for calculating the ledger balance.
+            "ledger__transactions",
             "ledger__transactions__reversal",
-            "ledger__transactions__reversal__state",
-            "ledger__transactions__reversal__quantity",
         ).order_by("uuid")
 
 
@@ -113,10 +115,10 @@ class TransactionViewSet(
 
       GET  /api/v1/transactions/
       GET  /api/v1/transactions/{transaction_uuid}/
-      POST /api/v1/transactions/?subsidy_uuid={subsidy_uuid}
+      POST /api/v1/transactions/
       POST /api/v1/transactions/{transaction_uuid}/reverse
 
-    Additional default actions can be added using the following mixins:
+    In the future, additional default actions can be added using the following mixins:
 
     * mixins.UpdateModelMixin (PUT and PATCH)
     * mixins.DestroyModelMixin (DELETE)
@@ -146,7 +148,35 @@ class TransactionViewSet(
             "reverse": PERMISSION_CAN_CREATE_TRANSACTIONS,
         }
         permission_required = permission_for_action.get(self.request_action, PERMISSION_NOT_GRANTED)
-        return permission_required
+        return (permission_required,)
+
+    def get_permission_object(self):
+        """
+        For all non-"list" actions, get a enterprise_customer_uuid to check permissions against.
+
+        Specifically, this determines the context (enterprise_customer_uuid) to pass to the rule predicate(s).  We only
+        store the enterprise_customer_uuid in the Subsidy object, so depending on the type of request, different paths
+        to resolve the Subsidy are taken.
+        """
+        enterprise_customer_uuid = None
+        subsidy = None
+        try:
+            # Intentionally do not key off of the request action. Instead, use request args to infer.
+            if self.requested_subsidy_uuid:
+                # If a specific subsidy was requested, this is probably a "create".
+                subsidy = Subsidy.objects.get(uuid=self.requested_subsidy_uuid)
+            elif self.requested_transaction_uuid:
+                # If a specific transaction was requested, this is probably a "retrieve" or "reverse".
+                subsidy = Subsidy.objects.get(ledger__transactions__in=[self.requested_transaction_uuid])
+        except Subsidy.DoesNotExist:
+            pass
+        except ValidationError:
+            # This can happen if the uuid in the request body does not parse.
+            pass
+        else:
+            if subsidy:
+                enterprise_customer_uuid = str(subsidy.enterprise_customer_uuid)
+        return enterprise_customer_uuid
 
     @property
     def requested_enterprise_customer_uuid(self):
@@ -165,6 +195,18 @@ class TransactionViewSet(
         return self.kwargs.get("uuid")
 
     @property
+    def requested_subsidy_uuid(self):
+        """
+        Fetch the subsidy UUID from the URL location.
+        """
+        if self.kwargs.get("subsidy_uuid"):
+            return self.kwargs.get("subsidy_uuid")
+        try:
+            return json.loads(self.request.body).get("subsidy_uuid")
+        except json.decoder.JSONDecodeError:
+            return None
+
+    @property
     def base_queryset(self):
         """
         Required by the ``PermissionRequiredForListingMixin``.
@@ -178,3 +220,87 @@ class TransactionViewSet(
             kwargs.update({"uuid": self.requested_transaction_uuid})
 
         return Transaction.objects.filter(**kwargs).order_by("uuid")
+
+    def create(self, request, *args, **kwargs):
+        """
+        Attempt to redeem subsidy for a given user and content.
+
+        This is called to create an enrollment (or entitlement) and associated Transaction.
+
+        Endpoint Location: POST /api/v1/transactions/
+
+        Request Arguments:
+        - ``subsidy_uuid`` (POST data, required):
+              The uuid (primary key) of the subsidy for which transactions should be created.
+        - ``learner_id`` (POST data, required):
+              The user for whom the transaction is written and for which a fulfillment should occur.
+        - ``content_key`` (POST data, required):
+              The content for which a fulfillment is created.
+        - ``access_policy_uuid`` (POST data, required):
+              The uuid of the policy that allowed the ledger transaction to be created.
+
+        Returns:
+            rest_framework.response.Response:
+                400: If there are missing or otherwise invalid input parameters.  Response body is JSON with a single
+                     `Error` key.
+                403: If the requester has insufficient create permissions, or the subisdy is not redeemable.  Response
+                     body is JSON with a single `Error` key.
+                201: If a Transaction was successfully created.  Response body is JSON with a serialized Transaction
+                     containing the following keys (sample values):
+                     {
+                         "uuid": "the-transaction-uuid",
+                         "state": "COMMITTED",
+                         "idempotency_key": "the-idempotency-key",
+                         "lms_user_id": 54321,
+                         "content_key": "demox_1234+2T2023",
+                         "quantity": 19900,
+                         "unit": "USD_CENTS",
+                         "reference_id": 1234,
+                         "reference_type": "NameOfSomeEnrollmentOrEntitlementModelTBD",
+                         "reference_table": "enrollments",
+                         "subsidy_access_policy_uuid": "a-policy-uuid",
+                         "metadata": {...},
+                         "created": "created-datetime",
+                         "modified": "modified-datetime",
+                         "reversals": []
+                     }
+        """
+        subsidy_uuid = request.data.get("subsidy_uuid")
+        learner_id = request.data.get("learner_id")
+        content_key = request.data.get("content_key")
+        access_policy_uuid = request.data.get("access_policy_uuid")
+        if not all([subsidy_uuid, learner_id, content_key, access_policy_uuid]):
+            return Response(
+                {
+                    "Error": (
+                        "One or more required fields were not provided in the request body: "
+                        "[subsidy_uuid, learner_id, content_key, access_policy_uuid]"
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            uuid.UUID(subsidy_uuid)
+            uuid.UUID(access_policy_uuid)
+        except ValueError:
+            return Response(
+                {"Error": "One or more UUID fields are not valid UUIDs: [subsidy_uuid, access_policy_uuid]"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            subsidy = Subsidy.objects.get(uuid=request.data.get("subsidy_uuid"))
+        except Subsidy.DoesNotExist:
+            return Response(
+                {"Error": "The provided subsidy_uuid does not match an existing subsidy."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        transaction, created = subsidy.redeem(learner_id, content_key, access_policy_uuid)
+        if not transaction:
+            return Response(
+                {"Error": "The given content_key is not currently redeemable for the given subsidy."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return Response(
+            TransactionSerializer(transaction).data,
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        )

--- a/enterprise_subsidy/apps/subsidy/api.py
+++ b/enterprise_subsidy/apps/subsidy/api.py
@@ -3,7 +3,7 @@ The python API.
 """
 
 from openedx_ledger.api import create_ledger
-from openedx_ledger.utils import create_idempotency_key_for_subsidy, create_idempotency_key_for_transaction
+from openedx_ledger.utils import create_idempotency_key_for_subsidy
 
 from enterprise_subsidy.apps.subsidy.models import Subsidy
 
@@ -44,10 +44,10 @@ def get_or_create_learner_credit_subsidy(
 
     if not subsidy.ledger:
         ledger = create_ledger(unit=default_unit, idempotency_key=create_idempotency_key_for_subsidy(subsidy))
+        ledger.save()
         subsidy.ledger = ledger
         # Seed the new ledger with its first transaction that reflects the requested starting balance:
-        idpk = create_idempotency_key_for_transaction(subsidy, default_starting_balance)
-        _ = subsidy.create_transaction(idpk, default_starting_balance, {})
+        subsidy.initialize_ledger()
 
     subsidy.save()
     return (subsidy, created)

--- a/enterprise_subsidy/apps/subsidy/tests/factories.py
+++ b/enterprise_subsidy/apps/subsidy/tests/factories.py
@@ -1,20 +1,52 @@
 """
 Test factories for subsidy models.
 """
-import datetime
 from uuid import uuid4
 
 import factory
 from factory.fuzzy import FuzzyText
-from faker import Faker
+from openedx_ledger.models import UnitChoices
+from openedx_ledger.test_utils.factories import LedgerFactory
 
 from enterprise_subsidy.apps.core.models import User
-from enterprise_subsidy.apps.subsidy.models import EnterpriseSubsidyFeatureRole, EnterpriseSubsidyRoleAssignment
+from enterprise_subsidy.apps.subsidy.models import (
+    EnterpriseSubsidyFeatureRole,
+    EnterpriseSubsidyRoleAssignment,
+    Subsidy,
+    SubsidyReferenceChoices
+)
 
 USER_PASSWORD = 'password'
 
 
+class SubsidyFactory(factory.django.DjangoModelFactory):
+    """
+    Test factory for the `Subsidy` model.
+    """
+    class Meta:
+        model = Subsidy
+
+    uuid = factory.LazyFunction(uuid4)
+    starting_balance = factory.Faker("random_int", min=10000, max=1000000)
+    ledger = factory.SubFactory(LedgerFactory)
+    unit = UnitChoices.USD_CENTS
+    reference_id = factory.Faker("lexify", text="????????")
+    reference_type = SubsidyReferenceChoices.OPPORTUNITY_PRODUCT_ID
+    enterprise_customer_uuid = factory.LazyFunction(uuid4)
+    active_datetime = factory.Faker("past_datetime")
+    expiration_datetime = factory.Faker("future_datetime")
+
+    # Register hook to seed initial value for this test subsidy.
+    initialize_ledger = factory.PostGenerationMethodCall("initialize_ledger")
+
+
 class UserFactory(factory.django.DjangoModelFactory):
+    """
+    Test factory for the `User` model.
+    """
+    class Meta:
+        model = User
+
     username = factory.Faker('user_name')
     password = factory.PostGenerationMethodCall('set_password', USER_PASSWORD)
     email = factory.Faker('email')
@@ -24,26 +56,23 @@ class UserFactory(factory.django.DjangoModelFactory):
     is_staff = False
     is_superuser = False
 
-    class Meta:
-        model = User
-
 
 class EnterpriseSubsidyFeatureRoleFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `EnterpriseSubsidyFeatureRole` model.
     """
-    name = FuzzyText(length=32)
-
     class Meta:
         model = EnterpriseSubsidyFeatureRole
+
+    name = FuzzyText(length=32)
 
 
 class EnterpriseSubsidyRoleAssignmentFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `EnterpriseSubisydRoleAssignment` model.
     """
-    role = factory.SubFactory(EnterpriseSubsidyFeatureRoleFactory)
-    enterprise_id = factory.LazyFunction(uuid4)
-
     class Meta:
         model = EnterpriseSubsidyRoleAssignment
+
+    role = factory.SubFactory(EnterpriseSubsidyFeatureRoleFactory)
+    enterprise_id = factory.LazyFunction(uuid4)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via edx-django-utils
@@ -26,7 +26,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==39.0.1
+cryptography==39.0.2
     # via
     #   pyjwt
     #   social-auth-core
@@ -54,7 +54,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -146,11 +146,11 @@ oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==5.1.0
+openedx-events==6.0.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-openedx-ledger==0.1.3
+openedx-ledger==0.1.6
     # via -r requirements/base.in
 packaging==23.0
     # via drf-yasg

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,11 +6,11 @@
 #
 certifi==2022.12.7
     # via requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==7.2.0
+coverage==7.2.1
     # via codecov
 distlib==0.3.6
     # via virtualenv
@@ -22,7 +22,7 @@ idna==3.4
     # via requests
 packaging==23.0
     # via tox
-platformdirs==3.0.0
+platformdirs==3.1.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -43,5 +43,5 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 urllib3==1.26.14
     # via requests
-virtualenv==20.19.0
+virtualenv==20.20.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/validation.txt
     #   django
-astroid==2.14.2
+astroid==2.15.0
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -41,7 +41,7 @@ cffi==1.15.1
     #   pynacl
 chardet==5.1.0
     # via diff-cover
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/validation.txt
     #   requests
@@ -71,11 +71,11 @@ coreschema==0.0.4
     #   -r requirements/validation.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==39.0.1
+cryptography==39.0.2
     # via
     #   -r requirements/validation.txt
     #   pyjwt
@@ -121,7 +121,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/validation.txt
 django-crum==0.7.9
     # via
@@ -210,7 +210,7 @@ exceptiongroup==1.1.0
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==17.0.0
+faker==17.6.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -301,7 +301,7 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.0.1
     # via -r requirements/validation.txt
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via
     #   -r requirements/validation.txt
     #   jaraco-classes
@@ -318,11 +318,11 @@ oauthlib==3.2.2
     #   -r requirements/validation.txt
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==5.1.0
+openedx-events==6.0.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-openedx-ledger==0.1.3
+openedx-ledger==0.1.6
     # via -r requirements/validation.txt
 packaging==23.0
     # via
@@ -338,13 +338,13 @@ pbr==5.11.1
     # via
     #   -r requirements/validation.txt
     #   stevedore
-pip-tools==6.12.2
+pip-tools==6.12.3
     # via -r requirements/pip-tools.txt
 pkginfo==1.9.6
     # via
     #   -r requirements/validation.txt
     #   twine
-platformdirs==3.0.0
+platformdirs==3.1.0
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -399,7 +399,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.16.2
+pylint==2.16.4
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -431,7 +431,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
@@ -445,7 +445,7 @@ python-dateutil==2.8.2
     #   -r requirements/validation.txt
     #   edx-drf-extensions
     #   faker
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/validation.txt
     #   code-annotations
@@ -498,7 +498,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/validation.txt
     #   twine
-rich==13.3.1
+rich==13.3.2
     # via
     #   -r requirements/validation.txt
     #   twine
@@ -601,7 +601,7 @@ urllib3==1.26.14
     #   -r requirements/validation.txt
     #   requests
     #   twine
-virtualenv==20.19.0
+virtualenv==20.20.0
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -613,11 +613,11 @@ wheel==0.38.4
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.14.1
+wrapt==1.15.0
     # via
     #   -r requirements/validation.txt
     #   astroid
-zipp==3.14.0
+zipp==3.15.0
     # via
     #   -r requirements/validation.txt
     #   importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,7 +10,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.14.2
+astroid==2.15.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -24,7 +24,7 @@ attrs==22.2.0
     #   -r requirements/test.txt
     #   openedx-events
     #   pytest
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 bleach==6.0.0
     # via readme-renderer
@@ -39,7 +39,7 @@ cffi==1.15.1
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/test.txt
     #   requests
@@ -67,11 +67,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.1
+cryptography==39.0.2
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -112,7 +112,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -204,7 +204,7 @@ exceptiongroup==1.1.0
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==17.0.0
+faker==17.6.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -286,7 +286,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mock==5.0.1
     # via -r requirements/test.txt
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
 mysqlclient==2.1.1
     # via
@@ -301,11 +301,11 @@ oauthlib==3.2.2
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==5.1.0
+openedx-events==6.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.1.3
+openedx-ledger==0.1.6
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -321,7 +321,7 @@ pbr==5.11.1
     #   stevedore
 pkginfo==1.9.6
     # via twine
-platformdirs==3.0.0
+platformdirs==3.1.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -369,7 +369,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.16.2
+pylint==2.16.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -399,7 +399,7 @@ pynacl==1.5.0
     #   edx-django-utils
 pyproject-hooks==1.0.0
     # via build
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -413,7 +413,7 @@ python-dateutil==2.8.2
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   faker
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -463,7 +463,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.2
     # via twine
 ruamel-yaml==0.17.21
     # via
@@ -580,17 +580,17 @@ urllib3==1.26.14
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.19.0
+virtualenv==20.20.0
     # via
     #   -r requirements/test.txt
     #   tox
 webencodings==0.5.1
     # via bleach
-wrapt==1.14.1
+wrapt==1.15.0
     # via
     #   -r requirements/test.txt
     #   astroid
-zipp==3.14.0
+zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.1.3
     # via pip-tools
 packaging==23.0
     # via build
-pip-tools==6.12.2
+pip-tools==6.12.3
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.38.4
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.4.0
+setuptools==67.5.1
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -25,7 +25,7 @@ cffi==1.15.1
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/base.txt
     #   requests
@@ -42,7 +42,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==39.0.1
+cryptography==39.0.2
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -71,7 +71,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -194,11 +194,11 @@ oauthlib==3.2.2
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==5.1.0
+openedx-events==6.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.1.3
+openedx-ledger==0.1.6
     # via -r requirements/base.txt
 packaging==23.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.14.2
+astroid==2.15.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -33,7 +33,7 @@ cffi==1.15.1
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/test.txt
     #   requests
@@ -61,11 +61,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.1
+cryptography==39.0.2
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -106,7 +106,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -192,7 +192,7 @@ exceptiongroup==1.1.0
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==17.0.0
+faker==17.6.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -271,7 +271,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mock==5.0.1
     # via -r requirements/test.txt
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
 mysqlclient==2.1.1
     # via
@@ -286,11 +286,11 @@ oauthlib==3.2.2
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==5.1.0
+openedx-events==6.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.1.3
+openedx-ledger==0.1.6
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -304,7 +304,7 @@ pbr==5.11.1
     #   stevedore
 pkginfo==1.9.6
     # via twine
-platformdirs==3.0.0
+platformdirs==3.1.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -354,7 +354,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.16.2
+pylint==2.16.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -382,7 +382,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -396,7 +396,7 @@ python-dateutil==2.8.2
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   faker
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -442,7 +442,7 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.2
     # via twine
 ruamel-yaml==0.17.21
     # via
@@ -537,17 +537,17 @@ urllib3==1.26.14
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.19.0
+virtualenv==20.20.0
     # via
     #   -r requirements/test.txt
     #   tox
 webencodings==0.5.1
     # via bleach
-wrapt==1.14.1
+wrapt==1.15.0
     # via
     #   -r requirements/test.txt
     #   astroid
-zipp==3.14.0
+zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.14.2
+astroid==2.15.0
     # via
     #   pylint
     #   pylint-celery
@@ -30,7 +30,7 @@ cffi==1.15.1
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/base.txt
     #   requests
@@ -56,11 +56,11 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==39.0.1
+cryptography==39.0.2
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -95,7 +95,7 @@ distlib==0.3.6
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -175,7 +175,7 @@ exceptiongroup==1.1.0
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==17.0.0
+faker==17.6.0
     # via factory-boy
 fastavro==1.7.2
     # via
@@ -237,11 +237,11 @@ oauthlib==3.2.2
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==5.1.0
+openedx-events==6.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.1.3
+openedx-ledger==0.1.6
     # via -r requirements/base.txt
 packaging==23.0
     # via
@@ -253,7 +253,7 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==3.0.0
+platformdirs==3.1.0
     # via
     #   pylint
     #   virtualenv
@@ -291,7 +291,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.16.2
+pylint==2.16.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -313,7 +313,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   pytest-cov
     #   pytest-django
@@ -326,7 +326,7 @@ python-dateutil==2.8.2
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   faker
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via code-annotations
 python3-openid==3.2.0
     # via
@@ -440,7 +440,7 @@ urllib3==1.26.14
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==20.19.0
+virtualenv==20.20.0
     # via tox
-wrapt==1.14.1
+wrapt==1.15.0
     # via astroid

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -9,7 +9,7 @@ asgiref==3.6.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-astroid==2.14.2
+astroid==2.15.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -41,7 +41,7 @@ cffi==1.15.1
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -75,12 +75,12 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.1
+cryptography==39.0.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -127,7 +127,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -241,7 +241,7 @@ factory-boy==3.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==17.0.0
+faker==17.6.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -347,7 +347,7 @@ mock==5.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-classes
@@ -367,12 +367,12 @@ oauthlib==3.2.2
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==5.1.0
+openedx-events==6.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.1.3
+openedx-ledger==0.1.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -392,7 +392,7 @@ pkginfo==1.9.6
     # via
     #   -r requirements/quality.txt
     #   twine
-platformdirs==3.0.0
+platformdirs==3.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -452,7 +452,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.16.2
+pylint==2.16.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -486,7 +486,7 @@ pynacl==1.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -506,7 +506,7 @@ python-dateutil==2.8.2
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   faker
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -565,7 +565,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==13.3.1
+rich==13.3.2
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -682,7 +682,7 @@ urllib3==1.26.14
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.19.0
+virtualenv==20.20.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -691,12 +691,12 @@ webencodings==0.5.1
     # via
     #   -r requirements/quality.txt
     #   bleach
-wrapt==1.14.1
+wrapt==1.15.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-zipp==3.14.0
+zipp==3.15.0
     # via
     #   -r requirements/quality.txt
     #   importlib-metadata


### PR DESCRIPTION
Before this change, POST /api/v1/transactions/ inherits the default create action to create a Transaction.  After this change, it is actually hooked up to the redeem() function which contains the rest of the business logic to redeem a subsidy, aside from just the creation of a Transaction.

ENT-6836