### PR TITLE
docs: Remove repo specific CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,0 @@
-# How to contribute
-
-This is an Open edX repo, and we welcome your contributions!
-Please read the [contributing guidelines](https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/index.html).
-
-
-


### PR DESCRIPTION
We now have a org wide CONTRIBUTING.md that points to our correct
general contributing guidelines.  We don't need repo specific ones that
forward to other contributing docs.
