### PR TITLE
feat: adding an enterprise catalog oauth client

### DIFF
--- a/enterprise_subsidy/apps/api_client/enterprise_catalog.py
+++ b/enterprise_subsidy/apps/api_client/enterprise_catalog.py
@@ -1,0 +1,81 @@
+"""
+Enterprise Catalog api client for the subsidy service.
+"""
+import logging
+from urllib.parse import urljoin
+
+import requests
+from django.conf import settings
+
+from enterprise_subsidy.apps.api_client.base_oauth import BaseOAuthClient
+
+logger = logging.getLogger(__name__)
+
+
+class EnterpriseCatalogApiClient(BaseOAuthClient):
+    """
+    API client for calls to the enterprise service.
+    """
+    api_base_url = urljoin(settings.ENTERPRISE_CATALOG_URL, 'api/v1/')
+    enterprise_customer_endpoint = urljoin(api_base_url, 'enterprise-customer/')
+
+    def enterprise_customer_url(self, enterprise_customer_uuid):
+        return urljoin(
+            self.enterprise_customer_endpoint,
+            f"{enterprise_customer_uuid}/",
+        )
+
+    def content_metadata_url(self, enterprise_customer_uuid, content_identifier):
+        return urljoin(
+            self.enterprise_customer_url(enterprise_customer_uuid),
+            f'content-metadata/{content_identifier}/'
+        )
+
+    def get_course_price(self, enterprise_customer_uuid, content_identifier):
+        """
+        Returns the price of a content as it's defined within the entitlements of the Enterprise Catalog's content
+        metadata record for a piece of content.
+
+        Arguments:
+            enterprise_customer_uuid (UUID): UUID of the customer associated with an enterprise
+            content_identifier (str): **Either** the content UUID or content key identifier for a content record.
+                Note: the content needs to be owned by a catalog associated with the provided customer else this
+                method will throw an HTTPError.
+        Returns:
+            Pricing (list of dicts): Array containing mappings of an individual content's course price associated with
+            a each of it's course mode
+        Raises:
+            requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
+            the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
+            does not exist, or is not present in a catalog associated with the customer.
+        """
+        course_details = self.get_content_metadata_for_customer(enterprise_customer_uuid, content_identifier)
+        return course_details.get('entitlements')
+
+    def get_content_metadata_for_customer(self, enterprise_customer_uuid, content_identifier):
+        """
+        Returns Enterprise Customer related data for a specified piece on content.
+
+        Arguments:
+            enterprise_customer_uuid (UUID): UUID of the customer associated with an enterprise
+            content_identifier (str): **Either** the content UUID or content key identifier for a content record.
+                Note: the content needs to be owned by a catalog associated with the provided customer else this
+                method will throw an HTTPError.
+        Returns:
+            response (dict): JSON response object associated with a content metadata record
+        Raises:
+            requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
+            the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
+            does not exist, or is not present in a catalog associated with the customer.
+        """
+        content_metadata_url = self.content_metadata_url(enterprise_customer_uuid, content_identifier)
+        try:
+            response = self.client.get(content_metadata_url)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as exc:
+            if hasattr(response, 'text'):
+                logger.error(
+                    f'Failed to fetch enterprise customer data for {enterprise_customer_uuid} because {response.text}',
+                )
+            raise exc

--- a/enterprise_subsidy/apps/api_client/tests/test_enterprise_catalog.py
+++ b/enterprise_subsidy/apps/api_client/tests/test_enterprise_catalog.py
@@ -1,0 +1,111 @@
+import os
+from unittest import mock
+from uuid import uuid4
+
+import ddt
+from django.conf import settings
+from django.test import TestCase
+
+from enterprise_subsidy.apps.api_client.enterprise_catalog import EnterpriseCatalogApiClient
+from test_utils.utils import MockResponse
+
+
+@ddt.ddt
+class EnterpriseCatalogApiClientTests(TestCase):
+    """
+    Tests for the enterprise catalog api client.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.enterprise_customer_uuid = uuid4()
+        cls.user_id = 3
+        cls.user_email = 'ayy@lmao.com'
+        cls.course_key = 'edX+DemoX'
+        cls.course_uuid = uuid4()
+        cls.courserun_key = 'course-v1:edX+DemoX+Demo_Course'
+
+        cls.course_entitlements = [
+            {'mode': 'verified', 'price': '149.00', 'currency': 'USD', 'sku': '8A47F9E', 'expires': 'null'}
+        ]
+        cls.course_metadata = {
+            'key': cls.course_key,
+            'content_type': 'course',
+            'uuid': cls.course_uuid,
+            'title': 'Demonstration Course',
+            'course_runs': [{
+                'key': cls.courserun_key,
+                'uuid': '00f8945b-bb50-4c7a-98f4-2f2f6178ff2f',
+                'title': 'Demonstration Course',
+                'external_key': None,
+                'seats': [{
+                    'type': 'verified',
+                    'price': '149.00',
+                    'currency': 'USD',
+                    'upgrade_deadline': '2023-05-26T15:45:32.494051Z',
+                    'upgrade_deadline_override': None,
+                    'credit_provider': None,
+                    'credit_hours': None,
+                    'sku': '8CF08E5',
+                    'bulk_sku': 'A5B6DBE'
+                }, {
+                    'type': 'audit',
+                    'price': '0.00',
+                    'currency': 'USD',
+                    'upgrade_deadline': None,
+                    'upgrade_deadline_override': None,
+                    'credit_provider': None,
+                    'credit_hours': None,
+                    'sku': '68EFFFF',
+                    'bulk_sku': None
+                }],
+                'start': '2013-02-05T05:00:00Z',
+                'end': None,
+                'go_live_date': None,
+                'enrollment_start': None,
+                'enrollment_end': None,
+                'is_enrollable': True,
+                'availability': 'Current',
+                'course': 'edX+DemoX',
+                'first_enrollable_paid_seat_price': 149,
+                'enrollment_count': 0,
+                'recent_enrollment_count': 0,
+                'course_uuid': cls.course_uuid,
+            }],
+            'entitlements': cls.course_entitlements,
+            'modified': '2022-05-26T15:46:24.355321Z',
+            'additional_metadata': None,
+            'enrollment_count': 0,
+            'recent_enrollment_count': 0,
+            'course_run_keys': [cls.courserun_key],
+            'content_last_modified': '2023-03-06T20:56:46.003840Z',
+            'enrollment_url': 'https://foobar.com',
+            'active': False
+        }
+
+    @mock.patch('enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient', return_value=mock.MagicMock())
+    def test_successful_fetch_course_content_metadata(self, mock_oauth_client):
+        """
+        Test the enterprise catalog client's ability to handle api requests to fetch content metadata from the catalog
+        service.
+        """
+        mock_oauth_client.return_value.get.return_value = MockResponse(self.course_metadata, 200)
+        enterprise_catalog_client = EnterpriseCatalogApiClient()
+        response = enterprise_catalog_client.get_content_metadata_for_customer(
+            self.enterprise_customer_uuid, self.course_key
+        )
+        assert response == self.course_metadata
+
+    @mock.patch('enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient', return_value=mock.MagicMock())
+    def test_successful_fetch_course_price(self, mock_oauth_client):
+        """
+        Test the enterprise catalog client's ability to handle api requests to fetch content metadata from the catalog
+        service and return formatted pricing data on the content.
+        """
+        mock_oauth_client.return_value.get.return_value = MockResponse(self.course_metadata, 200)
+        enterprise_catalog_client = EnterpriseCatalogApiClient()
+        response = enterprise_catalog_client.get_course_price(
+            self.enterprise_customer_uuid, self.course_key
+        )
+        assert response == self.course_entitlements

--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -23,6 +23,8 @@ def root(*path_fragments):
 
 
 LMS_URL = os.environ.get('LMS_URL', 'localhost:18000')
+ENTERPRISE_CATALOG_URL = os.environ.get('ENTERPRISE_CATALOG_URL', 'localhost:18160')
+
 BULK_ENROLL_REQUEST_TIMEOUT_SECONDS = os.environ.get('BULK_ENROLL_REQUEST_TIMEOUT_SECONDS', 20)
 
 # SECURITY WARNING: keep the secret key used in production secret!

--- a/enterprise_subsidy/settings/devstack.py
+++ b/enterprise_subsidy/settings/devstack.py
@@ -53,3 +53,4 @@ JWT_AUTH.update({
 })
 
 LMS_URL = 'http://edx.devstack.lms:18000'
+ENTERPRISE_CATALOG_URL = 'http://enterprise.catalog.app:18160'


### PR DESCRIPTION
### Description
Added oauth enterprise catalog service oauth client to the service. 

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
