### PR TITLE
feat: add venv for editible pips

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  language-pack-en \
  locales \
  python3.8 \
+ python3.8-venv \
  python3-pip \
  libmysqlclient-dev \
  libssl-dev \
@@ -34,6 +35,9 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  gcc \
  make
 
+ENV VIRTUAL_ENV=/edx/venvs/enterprise-subsidy
+RUN python3.8 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN pip install --upgrade pip setuptools
 # delete apt package lists because we do not need them inflating our image

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  libssl-dev \
  python3-dev \
  gcc \
+ git \
  make
 
 ENV VIRTUAL_ENV=/edx/venvs/enterprise-subsidy


### PR DESCRIPTION
### Description

- install `python3.8-venv` apt package so we can properly venv
- make use of a `/edx/venvs` folder (outside of the `app`) so local volume mounts don't interfere
- install `git` apt package to avoid [a confusing error message](https://github.com/certbot/certbot/issues/4382) when doing `pip freeze | grep ledger`

### Testing

```
root@e0d0890f0fa1:/edx/app/enterprise-subsidy# pip install -e /edx/src/openedx-ledger
...
Installing collected packages: openedx-ledger
  Attempting uninstall: openedx-ledger
    Found existing installation: openedx-ledger 0.1.6
    Uninstalling openedx-ledger-0.1.6:
      Successfully uninstalled openedx-ledger-0.1.6
  Running setup.py develop for openedx-ledger
Successfully installed openedx-ledger-0.1.6
root@e0d0890f0fa1:/edx/app/enterprise-subsidy# pip freeze | grep ledger
# Editable Git install with no remote (openedx-ledger==0.1.6)
-e /edx/src/openedx-ledger
root@e0d0890f0fa1:/edx/app/enterprise-subsidy#
```
