### PR TITLE
feat: list() and retrieve() transactions with more filtering

### DIFF
--- a/enterprise_subsidy/apps/api/v1/tests/mixins.py
+++ b/enterprise_subsidy/apps/api/v1/tests/mixins.py
@@ -24,6 +24,7 @@ from enterprise_subsidy.apps.subsidy.tests.factories import (
 )
 
 STATIC_LMS_USER_ID = 999
+STATIC_ENTERPRISE_UUID = str(uuid.uuid4())
 
 
 class JwtMixin():
@@ -70,7 +71,7 @@ class APITestMixin(JwtMixin, APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.enterprise_uuid = str(uuid.uuid4())
+        self.enterprise_uuid = STATIC_ENTERPRISE_UUID
         self.enterprise_name = 'Test Enterprise'
         self.enterprise_slug = 'test-enterprise'
         self.desired_system_wide_role = None
@@ -100,7 +101,7 @@ class APITestMixin(JwtMixin, APITestCase):
         """
         self.desired_system_wide_role = SYSTEM_ENTERPRISE_OPERATOR_ROLE
         self.desired_feature_role = ENTERPRISE_SUBSIDY_OPERATOR_ROLE
-        self.set_up_user_with_assignments(is_staff=True)
+        self.set_up_user_with_assignments(is_staff=True, enterprise_uuids=['*'])
 
     def set_up_user_with_assignments(self, is_staff=False, enterprise_uuids=None):
         """
@@ -136,7 +137,7 @@ class APITestMixin(JwtMixin, APITestCase):
             self.role_assignment = EnterpriseSubsidyRoleAssignmentFactory(
                 role=self.role,
                 user=user or self.user,
-                enterprise_id=enterprise_uuid,
+                enterprise_id=enterprise_uuid if enterprise_uuid != '*' else None,
             )
 
     def assign_implicit_jwt_system_wide_role(self, system_wide_role=None, jwt_contexts=None):

--- a/enterprise_subsidy/apps/api/v1/utils.py
+++ b/enterprise_subsidy/apps/api/v1/utils.py
@@ -3,7 +3,17 @@ Common utility functions for the subsidy API.
 """
 import uuid
 
+from edx_rest_framework_extensions.auth.jwt.authentication import get_decoded_jwt_from_auth
+from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 from rest_framework.exceptions import ParseError
+
+
+def get_decoded_jwt_from_auth_or_cookie(request):
+    """
+    Get the JWT token from the request and decode it.  For some reason, this isn't just defined in
+    edx_rest_framework_extensions.
+    """
+    return get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
 
 
 def get_enterprise_uuid_from_request_query_params(request):

--- a/enterprise_subsidy/apps/api/v1/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v1/views/transaction.py
@@ -53,7 +53,7 @@ class TransactionViewSet(
     serializer_class = TransactionSerializer
 
     # Fields that control permissions for 'list' actions, required by PermissionRequiredForListingMixin.
-    list_lookup_field = "ledger__subisidy__enterprise_customer_uuid"
+    list_lookup_field = "ledger__subsidy__enterprise_customer_uuid"
     allowed_roles = [ENTERPRISE_SUBSIDY_ADMIN_ROLE, ENTERPRISE_SUBSIDY_LEARNER_ROLE, ENTERPRISE_SUBSIDY_OPERATOR_ROLE]
     role_assignment_class = EnterpriseSubsidyRoleAssignment
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -98,7 +98,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -150,7 +150,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-openedx-ledger==0.1.7
+openedx-ledger==0.1.8
     # via -r requirements/base.in
 packaging==23.0
     # via drf-yasg
@@ -223,9 +223,9 @@ six==1.16.0
     #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,11 +10,11 @@ charset-normalizer==3.1.0
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==7.2.1
+coverage==7.2.2
     # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.9.0
+filelock==3.10.0
     # via
     #   tox
     #   virtualenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -71,7 +71,7 @@ coreschema==0.0.4
     #   -r requirements/validation.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.1
+coverage[toml]==7.2.2
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
@@ -179,7 +179,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
@@ -191,7 +191,7 @@ edx-drf-extensions==8.4.1
     #   edx-rbac
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via -r requirements/validation.txt
 edx-opaque-keys[django]==2.3.0
     # via
@@ -218,7 +218,7 @@ fastavro==1.7.3
     # via
     #   -r requirements/validation.txt
     #   openedx-events
-filelock==3.9.0
+filelock==3.10.0
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -322,7 +322,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-openedx-ledger==0.1.7
+openedx-ledger==0.1.8
     # via -r requirements/validation.txt
 packaging==23.0
     # via
@@ -543,11 +543,11 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/validation.txt
     #   pydocstyle
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/validation.txt
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   -r requirements/validation.txt
     #   edx-auth-backends
@@ -609,7 +609,7 @@ webencodings==0.5.1
     # via
     #   -r requirements/validation.txt
     #   bleach
-wheel==0.38.4
+wheel==0.40.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -67,7 +67,7 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.1
+coverage[toml]==7.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -173,7 +173,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -183,7 +183,7 @@ edx-drf-extensions==8.4.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via -r requirements/test.txt
 edx-opaque-keys[django]==2.3.0
     # via
@@ -212,7 +212,7 @@ fastavro==1.7.3
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.9.0
+filelock==3.10.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -305,7 +305,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.1.7
+openedx-ledger==0.1.8
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -503,11 +503,11 @@ slumber==0.7.1
     #   edx-rest-api-client
 snowballstemmer==2.2.0
     # via sphinx
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -16,7 +16,7 @@ pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
     # via build
-wheel==0.38.4
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -121,7 +121,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -198,7 +198,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.1.7
+openedx-ledger==0.1.8
     # via -r requirements/base.txt
 packaging==23.0
     # via
@@ -314,11 +314,11 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -343,7 +343,7 @@ urllib3==1.26.15
     #   requests
 zope-event==4.6
     # via gevent
-zope-interface==5.5.2
+zope-interface==6.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -61,7 +61,7 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.1
+coverage[toml]==7.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -161,7 +161,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -171,7 +171,7 @@ edx-drf-extensions==8.4.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via
     #   -r requirements/quality.in
     #   -r requirements/test.txt
@@ -200,7 +200,7 @@ fastavro==1.7.3
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.9.0
+filelock==3.10.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -290,7 +290,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.1.7
+openedx-ledger==0.1.8
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -481,11 +481,11 @@ slumber==0.7.1
     #   edx-rest-api-client
 snowballstemmer==2.2.0
     # via pydocstyle
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -56,7 +56,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.1
+coverage[toml]==7.2.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -148,7 +148,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -158,7 +158,7 @@ edx-drf-extensions==8.4.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via -r requirements/test.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -181,7 +181,7 @@ fastavro==1.7.3
     # via
     #   -r requirements/base.txt
     #   openedx-events
-filelock==3.9.0
+filelock==3.10.0
     # via
     #   tox
     #   virtualenv
@@ -241,7 +241,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.1.7
+openedx-ledger==0.1.8
     # via -r requirements/base.txt
 packaging==23.0
     # via
@@ -394,11 +394,11 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -75,7 +75,7 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.1
+coverage[toml]==7.2.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -201,7 +201,7 @@ edx-django-release-util==1.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -213,7 +213,7 @@ edx-drf-extensions==8.4.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-rbac
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -251,7 +251,7 @@ fastavro==1.7.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.9.0
+filelock==3.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -372,7 +372,7 @@ openedx-events==7.0.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.1.7
+openedx-ledger==0.1.8
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -616,12 +616,12 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
Before this change, anybody with learner or higher permissions on any context could perform any REST operation on transactions not their own. After this change, requesters must explicitly have admin or operator privileges on a given enterprise customer in order to list(), retrieve(), (etc.), transactions that do not have a lms_user_id matching that of the requester.

ENT-6886