### PR TITLE
feat: add subsidy can_redeem action to API

### DIFF
--- a/enterprise_subsidy/apps/api/v1/views/subsidy.py
+++ b/enterprise_subsidy/apps/api/v1/views/subsidy.py
@@ -2,13 +2,17 @@
 Views for the enterprise-subsidy service relating to the Subsidy model
  service.
 """
+from django.utils.functional import cached_property
 from edx_rbac.mixins import PermissionRequiredForListingMixin
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from rest_framework import mixins, permissions, viewsets
+from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from enterprise_subsidy.apps.api.v1 import utils
-from enterprise_subsidy.apps.api.v1.serializers import SubsidySerializer
+from enterprise_subsidy.apps.api.v1.serializers import SubsidySerializer, TransactionSerializer
+from enterprise_subsidy.apps.subsidy.api import can_redeem
 from enterprise_subsidy.apps.subsidy.constants import (
     ENTERPRISE_SUBSIDY_ADMIN_ROLE,
     ENTERPRISE_SUBSIDY_OPERATOR_ROLE,
@@ -53,22 +57,22 @@ class SubsidyViewSet(
             # anticipation that other write actions will be added soon.
             "list": PERMISSION_CAN_READ_SUBSIDIES,
             "retrieve": PERMISSION_CAN_READ_SUBSIDIES,
+            "can_redeem": PERMISSION_CAN_READ_SUBSIDIES,
         }
         permission_required = permission_for_action.get(self.request_action, PERMISSION_NOT_GRANTED)
         return [permission_required]
 
     def get_permission_object(self):
         """
-        Determine the correct enterprise customer uuid that role-based
-        permissions should be checked against.
+        Determine the correct enterprise customer uuid string that role-based
+        permissions should be checked against, or None if no such
+        customer UUID can be determined from the request payload.
         """
         if self.requested_enterprise_customer_uuid:
-            return self.requested_enterprise_customer_uuid
-        try:
-            subsidy_record = Subsidy.objects.get(uuid=self.requested_subsidy_uuid)
-            return str(subsidy_record.enterprise_customer_uuid)
-        except Subsidy.DoesNotExist:
-            return None
+            context = self.requested_enterprise_customer_uuid
+        else:
+            context = getattr(self.requested_subsidy, 'enterprise_customer_uuid', None)
+        return str(context) if context else None
 
     @property
     def requested_enterprise_customer_uuid(self):
@@ -85,6 +89,16 @@ class SubsidyViewSet(
         For detail endpoints, the PK can simply be found in ``self.kwargs``.
         """
         return self.kwargs.get("uuid")
+
+    @cached_property
+    def requested_subsidy(self):
+        """
+        Returns the Subsidy instance for the requested subsidy uuid.
+        """
+        try:
+            return Subsidy.objects.get(uuid=self.requested_subsidy_uuid)
+        except Subsidy.DoesNotExist:
+            return None
 
     @property
     def base_queryset(self):
@@ -104,3 +118,54 @@ class SubsidyViewSet(
             "ledger__transactions",
             "ledger__transactions__reversal",
         ).order_by("uuid")
+
+    @action(methods=['get'], detail=True)
+    def can_redeem(self, request, uuid):  # pylint: disable=unused-argument
+        """
+        /api/v1/subsidies/[subsidy-uuid]/can_redeem/
+        Answers the query "can the given user redeem for the given or content in this subsidy?"
+
+        Note that this endpoint will determine the price of the given content key
+        from the course-discovery service. The caller of this endpoint need not provide a price.
+
+        Path params:
+          uuid (URL path, required): The uuid (primary key) of the subsidy for which
+            transactions should be listed.
+
+        GET query params:
+          lms_user_id (required): The user to whom the query pertains.
+          content_key (required): The content to which the query pertains.
+
+        Returns:
+          An object indicating if there is sufficient value remainin in the
+          subsidy for this content, along with the quantity/unit required. e.g.
+
+          {
+            'can_redeem': true (or false),
+            'content_price': 19900,
+            'unit': 'USD_CENTS',
+          }
+        """
+        lms_user_id = request.query_params.get('lms_user_id')
+        content_key = request.query_params.get('content_key')
+        if not (lms_user_id and content_key):
+            return Response(
+                'A lms_user_id and content_key are required',
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        redeemable, content_price, existing_transaction = can_redeem(
+            self.requested_subsidy,
+            lms_user_id,
+            content_key,
+        )
+        response_payload = {
+            'can_redeem': redeemable,
+            'content_price': content_price,
+            'unit': self.requested_subsidy.unit,
+            'existing_transaction': TransactionSerializer(
+                existing_transaction
+            ).data if existing_transaction else None
+        }
+
+        return Response(response_payload, status=status.HTTP_200_OK)

--- a/enterprise_subsidy/apps/api/v1/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v1/views/transaction.py
@@ -338,7 +338,7 @@ class TransactionViewSet(
         """
         base_response = super().list(request, *args, **kwargs)
 
-        if self.request.query_params.get("include_aggregates") == "true":
+        if self.request.query_params.get("include_aggregates", "").lower() == "true":
             subsidy = Subsidy.objects.get(uuid=self.requested_subsidy_uuid)
             aggregates = {
                 "unit": subsidy.unit,

--- a/enterprise_subsidy/apps/subsidy/rules.py
+++ b/enterprise_subsidy/apps/subsidy/rules.py
@@ -28,7 +28,12 @@ def _user_has_explicit_access_via_feature_role(user, context, feature_role):
     """
     if not context:
         return False
-    return user_has_access_via_database(user, feature_role, EnterpriseSubsidyRoleAssignment, context)
+    return user_has_access_via_database(
+        user,
+        feature_role,
+        EnterpriseSubsidyRoleAssignment,
+        context,
+    )
 
 
 def _user_has_implicit_access_via_feature_role(user, context, feature_role):  # pylint: disable=unused-argument
@@ -42,7 +47,11 @@ def _user_has_implicit_access_via_feature_role(user, context, feature_role):  # 
         return False
     request = crum.get_current_request()
     decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
-    return request_user_has_implicit_access_via_jwt(decoded_jwt, feature_role, context)
+    return request_user_has_implicit_access_via_jwt(
+        decoded_jwt,
+        feature_role,
+        context,
+    )
 
 
 @rules.predicate

--- a/enterprise_subsidy/apps/subsidy/signals.py
+++ b/enterprise_subsidy/apps/subsidy/signals.py
@@ -25,7 +25,7 @@ def subsidy_pre_save(sender, instance, *args, **kwargs):  # pylint: disable=unus
     # If a transaction for the starting_balance is created,
     # that transaction record is also saved during
     # the create_ledger() call.
-    instance.ledger = create_ledger(
+    instance.ledger = create_ledger(  # pylint: disable=no-value-for-parameter,useless-suppression
         unit=instance.unit,
         subsidy_uuid=instance.uuid,
         initial_deposit=instance.starting_balance,

--- a/enterprise_subsidy/apps/subsidy/tests/__init__.py
+++ b/enterprise_subsidy/apps/subsidy/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Empty __init__.py for tests/ module.
+"""

--- a/enterprise_subsidy/apps/subsidy/tests/test_api.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_api.py
@@ -1,16 +1,24 @@
-from uuid import UUID, uuid4
+"""
+Tests for functions defined in the ``api.py`` module.
+"""
+from unittest import mock
+from uuid import uuid4
 
-import mock
 import pytest
 from django.test import TestCase
-from openedx_ledger import api as ledger_api
-from openedx_ledger.models import UnitChoices
+from openedx_ledger.models import Reversal, TransactionStateChoices, UnitChoices
+from openedx_ledger.test_utils.factories import TransactionFactory
 
 from enterprise_subsidy.apps.subsidy import api as subsidy_api
+
+from .factories import SubsidyFactory
 
 
 @pytest.fixture
 def learner_credit_fixture():
+    """
+    Simple Learner Credit Subsidy pytest fixture.
+    """
     subsidy, _ = subsidy_api.get_or_create_learner_credit_subsidy(
         reference_id="test-opp-product-id",
         default_title="Test Learner Credit Subsidy",
@@ -22,7 +30,7 @@ def learner_credit_fixture():
 
 
 @pytest.mark.django_db
-def test_create_learner_credit_subsidy(learner_credit_fixture):
+def test_create_learner_credit_subsidy(learner_credit_fixture):  # pylint: disable=redefined-outer-name
     """
     Test that a Subsidy, associated Ledger, and initial Transaction all are
     created successfully.  This can be easily confirmed by calling
@@ -32,11 +40,11 @@ def test_create_learner_credit_subsidy(learner_credit_fixture):
 
 
 @pytest.mark.django_db
-def test_get_learner_credit_subsidy(learner_credit_fixture):
+def test_get_learner_credit_subsidy(learner_credit_fixture):  # pylint: disable=redefined-outer-name
     """
     Test that a Subsidy can be retrieved, discarding supplied defaults.
     """
-    subsidy, created = subsidy_api.get_or_create_learner_credit_subsidy(
+    _, created = subsidy_api.get_or_create_learner_credit_subsidy(
         reference_id=learner_credit_fixture.reference_id,
         default_title="Default Title",
         default_enterprise_customer_uuid=uuid4(),
@@ -45,3 +53,87 @@ def test_get_learner_credit_subsidy(learner_credit_fixture):
     )
     assert not created
     assert learner_credit_fixture.current_balance() == 1000000
+
+
+class CanRedeemTestCase(TestCase):
+    """
+    Test the can_redeem() function.
+    """
+    def setUp(self):
+        self.enterprise_customer_uuid = uuid4()
+        self.subsidy_access_policy_uuid = uuid4()
+        self.subsidy = SubsidyFactory.create(
+            enterprise_customer_uuid=self.enterprise_customer_uuid,
+            starting_balance=100000,
+        )
+        self.subsidy.catalog_client = mock.MagicMock()
+        self.subsidy.catalog_client.get_course_price.return_value = '199.98'
+        self.lms_user_id = 42
+        self.content_key = 'some-content-key'
+        super().setUp()
+
+    def test_no_existing_transaction(self):
+        """
+        Tests that when no transaction for the given learner and content exists,
+        we return the result of ``Subsidy.can_redeem()``.
+        """
+        expected_redeemable = True
+        expected_price = 19998
+
+        actual_redeemable, actual_price, actual_transaction = subsidy_api.can_redeem(
+            self.subsidy, self.lms_user_id, self.content_key
+        )
+        self.assertEqual(expected_redeemable, actual_redeemable)
+        self.assertEqual(expected_price, actual_price)
+        self.assertIsNone(actual_transaction)
+
+    def test_existing_transaction_with_reversal(self):
+        """
+        Tests that when a reversed transaction for the given learner and content exists,
+        we return the result of ``Subsidy.can_redeem()``.
+        """
+        existing_transaction = TransactionFactory.create(
+            state=TransactionStateChoices.COMMITTED,
+            quantity=-19998,
+            ledger=self.subsidy.ledger,
+            lms_user_id=self.lms_user_id,
+            content_key=self.content_key
+        )
+        reversal = Reversal.objects.create(
+            transaction=existing_transaction,
+            idempotency_key=str(existing_transaction.idempotency_key) + '-reversed',
+            quantity=19998,
+            state=TransactionStateChoices.COMMITTED,
+        )
+        expected_redeemable = True
+        expected_price = 19998
+
+        actual_redeemable, actual_price, actual_transaction = subsidy_api.can_redeem(
+            self.subsidy, self.lms_user_id, self.content_key
+        )
+        self.assertEqual(expected_redeemable, actual_redeemable)
+        self.assertEqual(expected_price, actual_price)
+        self.assertEqual(existing_transaction, actual_transaction)
+        self.assertEqual(actual_transaction.reversal, reversal)
+
+    def test_existing_transaction_no_reversal(self):
+        """
+        Tests that when a transaction with no reversal for the given learner and content exists,
+        we return a result of ``False`` along with the content price and existing transaction.
+        """
+        existing_transaction = TransactionFactory.create(
+            state=TransactionStateChoices.COMMITTED,
+            quantity=-19998,
+            ledger=self.subsidy.ledger,
+            lms_user_id=self.lms_user_id,
+            content_key=self.content_key
+        )
+        expected_redeemable = False
+        expected_price = 19998
+
+        actual_redeemable, actual_price, actual_transaction = subsidy_api.can_redeem(
+            self.subsidy, self.lms_user_id, self.content_key
+        )
+        self.assertEqual(expected_redeemable, actual_redeemable)
+        self.assertEqual(expected_price, actual_price)
+        self.assertEqual(existing_transaction, actual_transaction)

--- a/enterprise_subsidy/apps/subsidy/tests/test_models.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_models.py
@@ -1,0 +1,110 @@
+"""
+Tests for functionality provided in the ``models.py`` module.
+"""
+from itertools import product
+from unittest import mock
+from uuid import uuid4
+
+import ddt
+from django.test import TestCase
+from openedx_ledger.models import TransactionStateChoices
+from openedx_ledger.test_utils.factories import TransactionFactory
+
+from ..models import CENTS_PER_DOLLAR
+from .factories import SubsidyFactory
+
+
+@ddt.ddt
+class SubsidyModelReadTestCase(TestCase):
+    """
+    Tests functionality defined in the ``Subsidy`` model.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        """
+        We assume that tests in this class don't mutate self.subsidy,
+        or if they do, take care to reset/clean-up the subsidy state
+        at the end of the test.  This allows us to use setUpTestData(),
+        which runs only once before every test in this TestCase is run.
+        """
+        cls.enterprise_customer_uuid = uuid4()
+        cls.subsidy = SubsidyFactory.create(
+            enterprise_customer_uuid=cls.enterprise_customer_uuid,
+        )
+        cls.subsidy.catalog_client = mock.MagicMock()
+        super().setUpTestData()
+
+    def test_price_for_content(self):
+        """
+        Tests that Subsidy.price_for_content returns the price of a piece
+        of content from the catalog client converted to cents of a dollar.
+        """
+        content_price_dollars_str = '199.98'
+
+        self.subsidy.catalog_client.get_course_price.return_value = content_price_dollars_str
+
+        actual_price_cents = self.subsidy.price_for_content('some-content-key')
+        expected_price_cents = 199.98 * CENTS_PER_DOLLAR
+        self.assertEqual(actual_price_cents, expected_price_cents)
+        self.subsidy.catalog_client.get_course_price.assert_called_once_with(
+            self.enterprise_customer_uuid,
+            'some-content-key',
+        )
+
+    @mock.patch('enterprise_subsidy.apps.subsidy.models.Subsidy.price_for_content')
+    @ddt.data(True, False)
+    def test_is_redeemable(self, expected_to_be_redeemable, mock_price_for_content):
+        """
+        Tests that Subsidy.is_redeemable() returns true when the subsidy
+        has enough remaining balance to cover the price of the given content,
+        and false otherwise.
+        """
+        # Mock the content price to be slightly too expensive if
+        # expected_to_be_redeemable is false;
+        # mock it to be slightly affordable if true.
+        constant = -100 if expected_to_be_redeemable else 100
+        content_price = self.subsidy.current_balance() + constant
+        mock_price_for_content.return_value = content_price
+
+        is_redeemable, actual_content_price = self.subsidy.is_redeemable('some-content-key')
+
+        self.assertEqual(is_redeemable, expected_to_be_redeemable)
+        self.assertEqual(content_price, actual_content_price)
+
+
+class SubsidyModelRedemptionTestCase(TestCase):
+    """
+    Tests functionality related to redemption on the Subsidy model
+    """
+    def setUp(self):
+        self.enterprise_customer_uuid = uuid4()
+        self.subsidy_access_policy_uuid = uuid4()
+        self.subsidy = SubsidyFactory.create(
+            enterprise_customer_uuid=self.enterprise_customer_uuid,
+        )
+        super().setUp()
+
+    def test_get_redemption(self):
+        """
+        Tests that get_redemption appropriately filters by learner and content identifiers.
+        """
+        alice_learner_id, bob_learner_id = (23, 42)
+        learner_content_pairs = list(product(
+            (alice_learner_id, bob_learner_id),
+            ('science-content-key', 'art-content-key'),
+        ))
+        for learner_id, content_key in learner_content_pairs:
+            TransactionFactory.create(
+                state=TransactionStateChoices.COMMITTED,
+                quantity=-1000,
+                ledger=self.subsidy.ledger,
+                lms_user_id=learner_id,
+                content_key=content_key
+            )
+
+        for learner_id, content_key in learner_content_pairs:
+            transaction = self.subsidy.get_redemption(learner_id, content_key)
+            self.assertEqual(transaction.lms_user_id, learner_id)
+            self.assertEqual(transaction.content_key, content_key)
+            self.assertEqual(transaction.quantity, -1000)
+            self.assertEqual(transaction.state, TransactionStateChoices.COMMITTED)

--- a/enterprise_subsidy/apps/subsidy/tests/test_rules.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_rules.py
@@ -9,16 +9,9 @@ from edx_rbac.utils import ALL_ACCESS_CONTEXT
 
 from enterprise_subsidy.apps.api.v1.tests.mixins import APITestMixin
 from enterprise_subsidy.apps.subsidy.constants import (
-    ENTERPRISE_SUBSIDY_ADMIN_ROLE,
-    ENTERPRISE_SUBSIDY_LEARNER_ROLE,
-    ENTERPRISE_SUBSIDY_OPERATOR_ROLE,
     PERMISSION_CAN_CREATE_TRANSACTIONS,
     PERMISSION_CAN_READ_SUBSIDIES,
-    PERMISSION_CAN_READ_TRANSACTIONS,
-    SYSTEM_ENTERPRISE_ADMIN_ROLE,
-    SYSTEM_ENTERPRISE_CATALOG_ADMIN_ROLE,
-    SYSTEM_ENTERPRISE_LEARNER_ROLE,
-    SYSTEM_ENTERPRISE_OPERATOR_ROLE
+    PERMISSION_CAN_READ_TRANSACTIONS
 )
 
 
@@ -28,6 +21,7 @@ class TestSubsidyAdminRBACPermissions(APITestMixin):
     Test defined django rules for authorization checks.
     """
     def set_up_user_by_type(self, user_type, authentication_type, jwt_context_override=False):
+        """ Inner helper for setting up JWT roles. """
         if user_type == "learner":
             self.set_up_learner()
         elif user_type == "admin":

--- a/enterprise_subsidy/urls.py
+++ b/enterprise_subsidy/urls.py
@@ -53,5 +53,5 @@ urlpatterns = oauth2_urlpatterns + [
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
     # Disable pylint import error because we don't install django-debug-toolbar
     # for CI build
-    import debug_toolbar  # pylint: disable=import-error
+    import debug_toolbar  # pylint: disable=import-error,useless-suppression
     urlpatterns.append(re_path(r'^__debug__/', include(debug_toolbar.urls)))


### PR DESCRIPTION
### Description
* Adds a `can_redeem` detail action to the `SubsidyViewSet`
* More strongly formalizes what it means to be redeemable.
* Adds unit tests for all the functions that deal with redeemability.

### Testing instructions

Add some, if applicable

### Merge checklist
- [x] All reviewers approved
- [x] CI build is green
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
