### PR TITLE
ENT-6886: Various list transactions enhancements

### DIFF
--- a/enterprise_subsidy/apps/api/serializers.py
+++ b/enterprise_subsidy/apps/api/serializers.py
@@ -1,4 +1,0 @@
-# Serializers that can be shared across multiple versions of the API
-# should be created here. As the API evolves, serializers may become more
-# specific to a particular version of the API. In this case, the serializers
-# in question should be moved to versioned sub-package.

--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -64,7 +64,7 @@ class TransactionSerializer(serializers.ModelSerializer):
 
     When using this serializer on a queryset, it can help with performance to prefectch the following:
 
-      .prefectch_related("ledger__unit", "reversal")
+      .prefetch_related("reversal")
     """
     unit = serializers.SerializerMethodField()
     reversal = ReversalSerializer(read_only=True)

--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -62,9 +62,9 @@ class TransactionSerializer(serializers.ModelSerializer):
     """
     Serializer for the `Transaction` model.
 
-    When using this serializer on a queryset, it can help with performance to prefectch the following:
+    When using this serializer on a queryset, it can help with performance to select_related reversals:
 
-      .prefetch_related("reversal")
+      Transaction.objects.select_related("reversal")
     """
     unit = serializers.SerializerMethodField()
     reversal = ReversalSerializer(read_only=True)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -140,7 +140,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-newrelic==8.7.0
+newrelic==8.7.1
     # via edx-django-utils
 oauthlib==3.2.2
     # via
@@ -150,7 +150,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-openedx-ledger==0.2.0
+openedx-ledger==0.2.1
     # via -r requirements/base.in
 packaging==23.0
     # via drf-yasg
@@ -190,7 +190,7 @@ pytz==2022.7.1
     #   openedx-ledger
 pyyaml==6.0
     # via edx-django-release-util
-redis==4.5.1
+redis==4.5.2
     # via openedx-ledger
 requests==2.28.2
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -211,7 +211,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==17.6.0
+faker==18.2.1
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -232,7 +232,7 @@ idna==3.4
     # via
     #   -r requirements/validation.txt
     #   requests
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   -r requirements/validation.txt
     #   keyring
@@ -310,7 +310,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -323,7 +323,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-openedx-ledger==0.2.0
+openedx-ledger==0.2.1
     # via -r requirements/validation.txt
 packaging==23.0
     # via
@@ -471,7 +471,7 @@ readme-renderer==37.3
     # via
     #   -r requirements/validation.txt
     #   twine
-redis==4.5.1
+redis==4.5.2
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -204,7 +204,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==17.6.0
+faker==18.2.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -227,7 +227,7 @@ idna==3.4
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   keyring
     #   sphinx
@@ -292,7 +292,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -305,7 +305,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.2.0
+openedx-ledger==0.2.1
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -436,7 +436,7 @@ pyyaml==6.0
     #   edx-django-release-util
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.2
     # via
     #   -r requirements/test.txt
     #   openedx-ledger

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -185,7 +185,7 @@ mysqlclient==2.1.1
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   openedx-ledger
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -198,7 +198,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.2.0
+openedx-ledger==0.2.1
     # via -r requirements/base.txt
 packaging==23.0
     # via
@@ -266,7 +266,7 @@ pyyaml==6.0
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   edx-django-release-util
-redis==4.5.1
+redis==4.5.2
     # via
     #   -r requirements/base.txt
     #   openedx-ledger

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -192,7 +192,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==17.6.0
+faker==18.2.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -213,7 +213,7 @@ idna==3.4
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   keyring
     #   twine
@@ -277,7 +277,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -290,7 +290,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.2.0
+openedx-ledger==0.2.1
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -418,7 +418,7 @@ pyyaml==6.0
     #   edx-django-release-util
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.2
     # via
     #   -r requirements/test.txt
     #   openedx-ledger

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -175,7 +175,7 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==17.6.0
+faker==18.2.1
     # via factory-boy
 fastavro==1.7.3
     # via
@@ -228,7 +228,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -241,7 +241,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.2.0
+openedx-ledger==0.2.1
     # via -r requirements/base.txt
 packaging==23.0
     # via
@@ -344,7 +344,7 @@ pyyaml==6.0
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-release-util
-redis==4.5.1
+redis==4.5.2
     # via
     #   -r requirements/base.txt
     #   openedx-ledger

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -241,7 +241,7 @@ factory-boy==3.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==17.6.0
+faker==18.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -267,7 +267,7 @@ idna==3.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -356,7 +356,7 @@ mysqlclient==2.1.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -372,7 +372,7 @@ openedx-events==7.0.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.2.0
+openedx-ledger==0.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -534,7 +534,7 @@ readme-renderer==37.3
     # via
     #   -r requirements/quality.txt
     #   twine
-redis==4.5.1
+redis==4.5.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
```
commit 7d3ad74d5b982205dc7ba3fbca03dcd83d9a189e
Author: Troy Sankey <tsankey@edx.org>
Date:   Mon Mar 20 20:15:54 2023 -0400

    feat: add transaction query params `content_key`, `learner_id`, `include_aggregates`
    
    ENT-6886

commit f611a8bc35bc8cc54cfe2e6e09359dc4e579ec15
Author: Troy Sankey <tsankey@edx.org>
Date:   Mon Mar 20 17:26:04 2023 -0400

    feat: list transactions filtering by subsidy_access_policy_uuid
    
    Also:
    * Rename transaction create() API parameter ``access_policy_uuid`` ->
      ``subsidy_access_policy_uuid`` for better consistency with serialized
      response objects.
    * Add a missing test ``test_retrieve_invalid_uuid()``
    * Fix 500 error when an invalid subsidy_uuid is passed via query_parameter.
    
    ENT-6886
```