### PR TITLE
feat: allowing for admins to search for transactions

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -87,13 +87,13 @@ class TransactionSerializer(serializers.ModelSerializer):
             "content_key",
             "quantity",
             "unit",  # Manually fetch from parent ledger via get_unit().
-            "reference_id",
-            "reference_type",
+            "fulfillment_identifier",
             "subsidy_access_policy_uuid",
             "metadata",
             "created",
             "modified",
             "reversal",  # Note that the `reversal` field is found via reverse relationship.
+            "external_reference",  # Note that the `external_reference` field is found via reverse relationship.
         ]
 
     def get_unit(self, obj):

--- a/enterprise_subsidy/apps/api_client/tests/test_enterprise.py
+++ b/enterprise_subsidy/apps/api_client/tests/test_enterprise.py
@@ -120,7 +120,6 @@ class EnterpriseApiClientTests(TestCase):
 
         Special case where the status code was still 2xx.
         """
-        expected_reference_id = 'test-reference-id'
         mock_oauth_client.return_value.post.return_value = MockResponse(
             {
                 'successes': [
@@ -150,7 +149,6 @@ class EnterpriseApiClientTests(TestCase):
 
         Special case where the status code was 4xx.
         """
-        expected_reference_id = 'test-reference-id'
         mock_oauth_client.return_value.post.return_value = MockResponse(None, 403)
         subsidy = SubsidyFactory(enterprise_customer_uuid=self.enterprise_customer_uuid, starting_balance=10000)
         transaction = TransactionFactory(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -166,7 +166,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-openedx-ledger==0.2.2
+openedx-ledger==0.3.1
     # via -r requirements/base.in
 packaging==23.0
     # via drf-yasg

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -337,7 +337,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-openedx-ledger==0.2.2
+openedx-ledger==0.3.1
     # via -r requirements/validation.txt
 packaging==23.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -321,7 +321,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.2.2
+openedx-ledger==0.3.1
     # via -r requirements/test.txt
 packaging==23.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -215,7 +215,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.2.2
+openedx-ledger==0.3.1
     # via -r requirements/base.txt
 packaging==23.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -306,7 +306,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.2.2
+openedx-ledger==0.3.1
     # via -r requirements/test.txt
 packaging==23.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -258,7 +258,7 @@ openedx-events==7.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.2.2
+openedx-ledger==0.3.1
     # via -r requirements/base.txt
 packaging==23.0
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -392,7 +392,7 @@ openedx-events==7.0.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.2.2
+openedx-ledger==0.3.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6933

### Description
1) adding search bar to subsidy's django admin transaction screen 
2) updated references to transaction reference ID's that are now aligned with the new `platform enrollment ID` and `GEAG allocation ID`

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
