### PR TITLE
feat: Take ledger locking into account

### DIFF
--- a/enterprise_subsidy/apps/subsidy/tests/test_models.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_models.py
@@ -140,3 +140,18 @@ class SubsidyModelRedemptionTestCase(TestCase):
             transaction.external_reference.first().external_fulfillment_provider,
             provider
         )
+
+    @mock.patch('enterprise_subsidy.apps.subsidy.models.Subsidy.price_for_content')
+    @mock.patch('enterprise_subsidy.apps.subsidy.models.Subsidy.enterprise_client')
+    def test_redeem_not_existing(self, mock_enterprise_client, mock_price_for_content):
+        learner_id = 1
+        content_key = "course-v1:edX+test+course"
+        subsidy_access_policy_uuid = str(uuid4())
+        mock_enterprise_fulfillment_uuid = str(uuid4())
+        mock_content_price = 1000
+        mock_price_for_content.return_value = mock_content_price
+        mock_enterprise_client.enroll.return_value = mock_enterprise_fulfillment_uuid
+        new_transaction, transaction_created = self.subsidy.redeem(learner_id, content_key, subsidy_access_policy_uuid)
+        assert transaction_created
+        assert new_transaction.state == TransactionStateChoices.COMMITTED
+        assert new_transaction.quantity == -mock_content_price

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   pyjwt
     #   social-auth-core
@@ -56,6 +56,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
+    #   social-auth-app-django
 django-cors-headers==3.14.0
     # via -r requirements/base.in
 django-crum==0.7.9
@@ -108,13 +109,13 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openedx-ledger
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.6.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
@@ -156,7 +157,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-newrelic==8.7.1
+newrelic==8.8.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via
@@ -168,7 +169,7 @@ openedx-events==7.0.0
     #   openedx-ledger
 openedx-ledger==0.3.1
     # via -r requirements/base.in
-packaging==23.0
+packaging==23.1
     # via drf-yasg
 pbr==5.11.1
     # via stevedore
@@ -201,7 +202,7 @@ python-dateutil==2.8.2
     # via edx-drf-extensions
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.in
     #   django
@@ -212,7 +213,7 @@ pyyaml==6.0
     # via
     #   drf-spectacular
     #   edx-django-release-util
-redis==4.5.3
+redis==4.5.4
     # via openedx-ledger
 requests==2.28.2
     # via
@@ -245,9 +246,9 @@ six==1.16.0
     #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via edx-auth-backends
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,32 +4,20 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.2
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.10.2
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -41,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/validation.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -22,7 +22,6 @@ attrs==22.2.0
     #   -r requirements/validation.txt
     #   jsonschema
     #   openedx-events
-    #   pytest
 bleach==6.0.0
     # via
     #   -r requirements/validation.txt
@@ -72,11 +71,11 @@ coreschema==0.0.4
     #   -r requirements/validation.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/validation.txt
     #   pyjwt
@@ -122,6 +121,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
+    #   social-auth-app-django
 django-cors-headers==3.14.0
     # via -r requirements/validation.txt
 django-crum==0.7.9
@@ -129,7 +129,7 @@ django-crum==0.7.9
     #   -r requirements/validation.txt
     #   edx-django-utils
     #   edx-rbac
-django-debug-toolbar==3.8.1
+django-debug-toolbar==4.0.0
     # via -r requirements/dev.in
 django-dynamic-fixture==3.1.2
     # via -r requirements/validation.txt
@@ -188,13 +188,13 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openedx-ledger
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.6.0
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
@@ -219,7 +219,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==18.3.0
+faker==18.4.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -227,7 +227,7 @@ fastavro==1.7.3
     # via
     #   -r requirements/validation.txt
     #   openedx-events
-filelock==3.10.2
+filelock==3.11.0
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -240,7 +240,7 @@ idna==3.4
     # via
     #   -r requirements/validation.txt
     #   requests
-importlib-metadata==6.1.0
+importlib-metadata==6.3.0
     # via
     #   -r requirements/validation.txt
     #   keyring
@@ -324,7 +324,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-newrelic==8.7.1
+newrelic==8.8.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -339,7 +339,7 @@ openedx-events==7.0.0
     #   openedx-ledger
 openedx-ledger==0.3.1
     # via -r requirements/validation.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/validation.txt
@@ -353,7 +353,7 @@ pbr==5.11.1
     # via
     #   -r requirements/validation.txt
     #   stevedore
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
 pkginfo==1.9.6
     # via
@@ -363,7 +363,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/validation.txt
     #   jsonschema
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -400,7 +400,7 @@ pycryptodomex==3.17
     #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/validation.txt
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   -r requirements/validation.txt
     #   diff-cover
@@ -418,7 +418,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.1
+pylint==2.17.2
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -454,7 +454,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/validation.txt
     #   jsonschema
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
@@ -476,7 +476,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/validation.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/validation.txt
     #   django
@@ -494,7 +494,7 @@ readme-renderer==37.3
     # via
     #   -r requirements/validation.txt
     #   twine
-redis==4.5.3
+redis==4.5.4
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
@@ -522,7 +522,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/validation.txt
     #   twine
-rich==13.3.2
+rich==13.3.4
     # via
     #   -r requirements/validation.txt
     #   twine
@@ -567,11 +567,11 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/validation.txt
     #   pydocstyle
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via
     #   -r requirements/validation.txt
     #   edx-auth-backends
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   -r requirements/validation.txt
     #   edx-auth-backends
@@ -601,7 +601,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/validation.txt
     #   pylint

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,7 +10,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -24,7 +24,6 @@ attrs==22.2.0
     #   -r requirements/test.txt
     #   jsonschema
     #   openedx-events
-    #   pytest
 babel==2.12.1
     # via sphinx
 bleach==6.0.0
@@ -68,11 +67,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -113,6 +112,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
+    #   social-auth-app-django
 django-cors-headers==3.14.0
     # via -r requirements/test.txt
 django-crum==0.7.9
@@ -181,13 +181,13 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openedx-ledger
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.6.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
@@ -212,7 +212,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.3.0
+faker==18.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -220,7 +220,7 @@ fastavro==1.7.3
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.10.2
+filelock==3.11.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -235,7 +235,7 @@ idna==3.4
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.1.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   sphinx
@@ -308,7 +308,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==8.7.1
+newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -323,7 +323,7 @@ openedx-events==7.0.0
     #   openedx-ledger
 openedx-ledger==0.3.1
     # via -r requirements/test.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   build
@@ -341,7 +341,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -371,7 +371,7 @@ pycryptodomex==3.17
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   doc8
     #   readme-renderer
@@ -389,7 +389,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.1
+pylint==2.17.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -423,7 +423,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/test.txt
     #   jsonschema
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -445,7 +445,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   babel
@@ -461,7 +461,7 @@ pyyaml==6.0
     #   edx-django-release-util
 readme-renderer==37.3
     # via twine
-redis==4.5.3
+redis==4.5.4
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -488,7 +488,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
 ruamel-yaml==0.17.21
     # via
@@ -528,11 +528,11 @@ slumber==0.7.1
     #   edx-rest-api-client
 snowballstemmer==2.2.0
     # via sphinx
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -579,7 +579,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.40.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.6.1
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -43,7 +43,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -72,6 +72,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
+    #   social-auth-app-django
 django-cors-headers==3.14.0
     # via -r requirements/base.txt
 django-crum==0.7.9
@@ -129,13 +130,13 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openedx-ledger
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.6.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
@@ -202,7 +203,7 @@ mysqlclient==2.1.1
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   openedx-ledger
-newrelic==8.7.1
+newrelic==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -217,7 +218,7 @@ openedx-events==7.0.0
     #   openedx-ledger
 openedx-ledger==0.3.1
     # via -r requirements/base.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -279,7 +280,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.txt
     #   django
@@ -292,7 +293,7 @@ pyyaml==6.0
     #   -r requirements/production.in
     #   drf-spectacular
     #   edx-django-release-util
-redis==4.5.3
+redis==4.5.4
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -340,11 +341,11 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -22,7 +22,6 @@ attrs==22.2.0
     #   -r requirements/test.txt
     #   jsonschema
     #   openedx-events
-    #   pytest
 bleach==6.0.0
     # via readme-renderer
 certifi==2022.12.7
@@ -62,11 +61,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -107,6 +106,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
+    #   social-auth-app-django
 django-cors-headers==3.14.0
     # via -r requirements/test.txt
 django-crum==0.7.9
@@ -169,13 +169,13 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openedx-ledger
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.6.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
@@ -200,7 +200,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.3.0
+faker==18.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -208,7 +208,7 @@ fastavro==1.7.3
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.10.2
+filelock==3.11.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -221,7 +221,7 @@ idna==3.4
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.1.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   twine
@@ -293,7 +293,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==8.7.1
+newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -308,7 +308,7 @@ openedx-events==7.0.0
     #   openedx-ledger
 openedx-ledger==0.3.1
     # via -r requirements/test.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -324,7 +324,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -358,7 +358,7 @@ pycryptodomex==3.17
     #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   readme-renderer
     #   rich
@@ -374,7 +374,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.1
+pylint==2.17.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -406,7 +406,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/test.txt
     #   jsonschema
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -428,7 +428,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   django
@@ -443,7 +443,7 @@ pyyaml==6.0
     #   edx-django-release-util
 readme-renderer==37.3
     # via twine
-redis==4.5.3
+redis==4.5.4
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -467,7 +467,7 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
 ruamel-yaml==0.17.21
     # via
@@ -506,11 +506,11 @@ slumber==0.7.1
     #   edx-rest-api-client
 snowballstemmer==2.2.0
     # via pydocstyle
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -536,7 +536,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
@@ -21,7 +21,6 @@ attrs==22.2.0
     #   -r requirements/base.txt
     #   jsonschema
     #   openedx-events
-    #   pytest
 certifi==2022.12.7
     # via
     #   -r requirements/base.txt
@@ -57,11 +56,11 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -96,6 +95,7 @@ distlib==0.3.6
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
+    #   social-auth-app-django
 django-cors-headers==3.14.0
     # via -r requirements/base.txt
 django-crum==0.7.9
@@ -156,13 +156,13 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openedx-ledger
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.6.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
@@ -183,13 +183,13 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.3.0
+faker==18.4.0
     # via factory-boy
 fastavro==1.7.3
     # via
     #   -r requirements/base.txt
     #   openedx-events
-filelock==3.10.2
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
@@ -245,7 +245,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-newrelic==8.7.1
+newrelic==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -260,7 +260,7 @@ openedx-events==7.0.0
     #   openedx-ledger
 openedx-ledger==0.3.1
     # via -r requirements/base.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -274,7 +274,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/base.txt
     #   jsonschema
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   pylint
     #   virtualenv
@@ -312,7 +312,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.1
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -338,7 +338,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/base.txt
     #   jsonschema
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   pytest-cov
     #   pytest-django
@@ -357,7 +357,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.txt
     #   django
@@ -370,7 +370,7 @@ pyyaml==6.0
     #   code-annotations
     #   drf-spectacular
     #   edx-django-release-util
-redis==4.5.3
+redis==4.5.4
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -420,11 +420,11 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -447,7 +447,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 tox==3.28.0
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -9,7 +9,7 @@ asgiref==3.6.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -26,7 +26,6 @@ attrs==22.2.0
     #   -r requirements/test.txt
     #   jsonschema
     #   openedx-events
-    #   pytest
 bleach==6.0.0
     # via
     #   -r requirements/quality.txt
@@ -76,12 +75,12 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -128,6 +127,7 @@ django==3.2.18
     #   jsonfield2
     #   openedx-events
     #   openedx-ledger
+    #   social-auth-app-django
 django-cors-headers==3.14.0
     # via
     #   -r requirements/quality.txt
@@ -213,14 +213,14 @@ edx-django-release-util==1.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openedx-ledger
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.6.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -253,7 +253,7 @@ factory-boy==3.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==18.3.0
+faker==18.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -263,7 +263,7 @@ fastavro==1.7.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.10.2
+filelock==3.11.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -279,7 +279,7 @@ idna==3.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.1.0
+importlib-metadata==6.3.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -376,7 +376,7 @@ mysqlclient==2.1.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==8.7.1
+newrelic==8.8.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -396,7 +396,7 @@ openedx-ledger==0.3.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -417,7 +417,7 @@ pkgutil-resolve-name==1.3.10
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -458,7 +458,7 @@ pycryptodomex==3.17
     #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -477,7 +477,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.1
+pylint==2.17.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -516,7 +516,7 @@ pyrsistent==0.19.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jsonschema
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -546,7 +546,7 @@ python3-openid==3.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -565,7 +565,7 @@ readme-renderer==37.3
     # via
     #   -r requirements/quality.txt
     #   twine
-redis==4.5.3
+redis==4.5.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -596,7 +596,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==13.3.2
+rich==13.3.4
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -647,12 +647,12 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -683,7 +683,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
This is a followup from openedx_ledger changes in https://github.com/openedx/openedx-ledger/pull/17 to implement locking on the ledger object during transaction creation.

* POST /api/v1/transactions: add a new 429 response to  when the ledger is locked.
* POST /api/v1/transactions: update reponse code to 422 (was 403) when subsidy is not redeemable.
* Add basic model test for Subsidy.redeem(), and additional view tests to cover the above two bullets.
* Also, make sure the Transaction lifecycle fully progressess through either:
   - created -> pending -> committed
   - created -> pending -> failed
* make upgrade
  - remove codecov package from ci.txt

ENT-6835
