### PR TITLE
fix: content_key not found should respond with 422, and stop double-converting dollars to cents

### DIFF
--- a/enterprise_subsidy/apps/api/v1/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v1/views/transaction.py
@@ -28,7 +28,11 @@ from enterprise_subsidy.apps.subsidy.constants import (
     PERMISSION_CAN_READ_TRANSACTIONS,
     PERMISSION_NOT_GRANTED
 )
-from enterprise_subsidy.apps.subsidy.models import EnterpriseSubsidyRoleAssignment, Subsidy
+from enterprise_subsidy.apps.subsidy.models import (
+    ContentNotFoundForCustomerException,
+    EnterpriseSubsidyRoleAssignment,
+    Subsidy
+)
 
 logger = logging.getLogger(__name__)
 
@@ -454,6 +458,11 @@ class TransactionViewSet(
             return Response(
                 {"Error": "Attempt to lock the Ledger failed, please try again."},
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+        except ContentNotFoundForCustomerException:
+            return Response(
+                {"Error": "The given content_key is not in any catalog for this customer."},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
         if not transaction:
             return Response(

--- a/enterprise_subsidy/apps/api_client/enterprise_catalog.py
+++ b/enterprise_subsidy/apps/api_client/enterprise_catalog.py
@@ -75,9 +75,10 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
             content_identifier (str): **Either** the content UUID or content key identifier for a content record.
                 Note: the content needs to be owned by a catalog associated with the provided customer else this
                 method will throw an HTTPError.
+
         Returns:
-            Pricing (list of dicts): Array containing mappings of an individual content's course price associated with
-            a each of it's course mode
+            int: price of content in USD cents.
+
         Raises:
             requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
             the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content

--- a/enterprise_subsidy/apps/subsidy/tests/test_api.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_api.py
@@ -67,7 +67,7 @@ class CanRedeemTestCase(TestCase):
             starting_balance=100000,
         )
         self.subsidy.catalog_client = mock.MagicMock()
-        self.subsidy.catalog_client.get_course_price.return_value = '199.98'
+        self.subsidy.catalog_client.get_course_price.return_value = 19998
         self.lms_user_id = 42
         self.content_key = 'some-content-key'
         super().setUp()


### PR DESCRIPTION
This combo commit combines two unrelated fixes that are too hard to split up into two commits because they both touch the same lines of code:

* On redeem (create transaction) if the requested content_key is not found, the response should be 422 instead of 500.
* Stop double-converting dollars to cents.  Previously, transaction records would be written with quantity values 100x larger than they should have been.

Unticketed work.