### PR TITLE
feat: add geag variant to contentmetadata

### DIFF
--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -974,6 +974,9 @@ class ContentMetadataViewSetTests(APITestBase):
             "slug": "2u",
             "description": "2U, Trilogy, Getsmarter -- external source for 2u courses and programs"
         },
+        "additional_metadata": {
+            "variant_id": "79a95406-a9ac-49b3-a27c-44f3fd06092e"
+        }
     }
     mock_http_error_reason = 'Something Went Wrong'
     mock_http_error_url = 'foobar.com'
@@ -984,14 +987,19 @@ class ContentMetadataViewSetTests(APITestBase):
             'expected_content_key': content_key_1,
             'expected_content_price': 14900.0,
             'mock_metadata': edx_course_metadata,
-            'expected_source': 'edX'
+            'expected_source': 'edX',
+            'expected_mode': 'verified',
+            'expected_geag_variant_id': None,
         },
         {
             'expected_content_uuid': content_uuid_2,
             'expected_content_key': content_key_2,
             'expected_content_price': 59949,
             'mock_metadata': executive_education_course_metadata,
-            'expected_source': '2u'
+            'expected_source': '2u',
+            'expected_mode': 'paid-executive-education',
+            # generated randomly using a fair die
+            'expected_geag_variant_id': '79a95406-a9ac-49b3-a27c-44f3fd06092e',
         },
     )
     @ddt.unpack
@@ -1002,6 +1010,8 @@ class ContentMetadataViewSetTests(APITestBase):
         expected_content_price,
         mock_metadata,
         expected_source,
+        expected_mode,
+        expected_geag_variant_id,
     ):
         with mock.patch(
             'enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient',
@@ -1018,6 +1028,8 @@ class ContentMetadataViewSetTests(APITestBase):
                 'content_key': expected_content_key,
                 'source': expected_source,
                 'content_price': expected_content_price,
+                'mode': expected_mode,
+                'geag_variant_id': expected_geag_variant_id,
             }
 
             # Everything after this line is testing the view's cache
@@ -1030,6 +1042,8 @@ class ContentMetadataViewSetTests(APITestBase):
                 'content_key': expected_content_key,
                 'source': expected_source,
                 'content_price': expected_content_price,
+                'mode': expected_mode,
+                'geag_variant_id': expected_geag_variant_id,
             }
 
     def test_failure_no_permission(self):

--- a/enterprise_subsidy/apps/api/v1/views/content_metadata.py
+++ b/enterprise_subsidy/apps/api/v1/views/content_metadata.py
@@ -18,6 +18,7 @@ from rest_framework.status import HTTP_404_NOT_FOUND
 from enterprise_subsidy.apps.api.v1 import utils
 from enterprise_subsidy.apps.api.v1.decorators import require_at_least_one_query_parameter
 from enterprise_subsidy.apps.api_client.enterprise_catalog import EnterpriseCatalogApiClient
+from enterprise_subsidy.apps.content_metadata.api import summary_data_for_content
 from enterprise_subsidy.apps.subsidy.constants import (
     ENTERPRISE_SUBSIDY_ADMIN_ROLE,
     ENTERPRISE_SUBSIDY_LEARNER_ROLE,
@@ -99,7 +100,7 @@ class ContentMetadataViewSet(
                 enterprise_customer_uuid[0],
                 content_identifier
             )
-            content_summary = catalog_client.summary_data_for_content(content_data)
+            content_summary = summary_data_for_content(content_data)
             if not content_summary.get('content_price'):
                 logger.warning("Could not find course price in metadata for {content_identifier}")
         except requests.exceptions.HTTPError as exc:

--- a/enterprise_subsidy/apps/api/v1/views/content_metadata.py
+++ b/enterprise_subsidy/apps/api/v1/views/content_metadata.py
@@ -17,7 +17,7 @@ from rest_framework.status import HTTP_404_NOT_FOUND
 
 from enterprise_subsidy.apps.api.v1 import utils
 from enterprise_subsidy.apps.api.v1.decorators import require_at_least_one_query_parameter
-from enterprise_subsidy.apps.content_metadata.api import get_content_summary
+from enterprise_subsidy.apps.content_metadata.api import ContentMetadataApi
 from enterprise_subsidy.apps.subsidy.constants import (
     ENTERPRISE_SUBSIDY_ADMIN_ROLE,
     ENTERPRISE_SUBSIDY_LEARNER_ROLE,
@@ -62,6 +62,12 @@ class ContentMetadataViewSet(
         """
         return str(self.requested_enterprise_customer_uuid)
 
+    def content_metadata_api(self):
+        """
+        Api for interacting with catalog content
+        """
+        return ContentMetadataApi()
+
     @property
     def requested_enterprise_customer_uuid(self):
         """
@@ -94,7 +100,10 @@ class ContentMetadataViewSet(
                     content's associated product source
         """
         try:
-            content_summary = get_content_summary(enterprise_customer_uuid[0], content_identifier)
+            content_summary = self.content_metadata_api().get_content_summary(
+                enterprise_customer_uuid[0],
+                content_identifier
+            )
             if not content_summary.get('content_price'):
                 logger.warning("Could not find course price in metadata for {content_identifier}")
         except requests.exceptions.HTTPError as exc:

--- a/enterprise_subsidy/apps/api/v1/views/content_metadata.py
+++ b/enterprise_subsidy/apps/api/v1/views/content_metadata.py
@@ -17,8 +17,7 @@ from rest_framework.status import HTTP_404_NOT_FOUND
 
 from enterprise_subsidy.apps.api.v1 import utils
 from enterprise_subsidy.apps.api.v1.decorators import require_at_least_one_query_parameter
-from enterprise_subsidy.apps.api_client.enterprise_catalog import EnterpriseCatalogApiClient
-from enterprise_subsidy.apps.content_metadata.api import summary_data_for_content
+from enterprise_subsidy.apps.content_metadata.api import get_content_summary
 from enterprise_subsidy.apps.subsidy.constants import (
     ENTERPRISE_SUBSIDY_ADMIN_ROLE,
     ENTERPRISE_SUBSIDY_LEARNER_ROLE,
@@ -94,13 +93,8 @@ class ContentMetadataViewSet(
                 - The content metadata payload does not contain an appropriate entitlement mode and price or the
                     content's associated product source
         """
-        catalog_client = EnterpriseCatalogApiClient()
         try:
-            content_data = catalog_client.get_content_metadata_for_customer(
-                enterprise_customer_uuid[0],
-                content_identifier
-            )
-            content_summary = summary_data_for_content(content_data)
+            content_summary = get_content_summary(enterprise_customer_uuid[0], content_identifier)
             if not content_summary.get('content_price'):
                 logger.warning("Could not find course price in metadata for {content_identifier}")
         except requests.exceptions.HTTPError as exc:

--- a/enterprise_subsidy/apps/api_client/enterprise_catalog.py
+++ b/enterprise_subsidy/apps/api_client/enterprise_catalog.py
@@ -8,7 +8,6 @@ import requests
 from django.conf import settings
 
 from enterprise_subsidy.apps.api_client.base_oauth import BaseOAuthClient
-from enterprise_subsidy.apps.content_metadata.api import price_for_content, product_source_for_content
 
 logger = logging.getLogger(__name__)
 
@@ -31,47 +30,6 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
             self.enterprise_customer_url(enterprise_customer_uuid),
             f'content-metadata/{content_identifier}/'
         )
-
-    def get_product_source(self, enterprise_customer_uuid, content_identifier):
-        """
-        Returns the a specific piece of content's product source as it's defined within the content metadata of the
-        Enterprise Catalog service.
-
-        Arguments:
-            enterprise_customer_uuid (UUID): UUID of the customer associated with an enterprise
-            content_identifier (str): **Either** the content UUID or content key identifier for a content record.
-                Note: the content needs to be owned by a catalog associated with the provided customer else this
-                method will throw an HTTPError.
-        Returns:
-            Either `2U` or `edX` based on the content's product source content metadata field
-        Raises:
-            requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
-            the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
-            does not exist, or is not present in a catalog associated with the customer.
-        """
-        course_details = self.get_content_metadata_for_customer(enterprise_customer_uuid, content_identifier)
-        return product_source_for_content(course_details)
-
-    def get_course_price(self, enterprise_customer_uuid, content_identifier):
-        """
-        Returns the price of a content as it's defined within the entitlements of the Enterprise Catalog's content
-        metadata record for a piece of content.
-
-        Arguments:
-            enterprise_customer_uuid (UUID): UUID of the customer associated with an enterprise
-            content_identifier (str): **Either** the content UUID or content key identifier for a content record.
-                Note: the content needs to be owned by a catalog associated with the provided customer else this
-                method will throw an HTTPError.
-        Returns:
-            Pricing (list of dicts): Array containing mappings of an individual content's course price associated with
-            a each of it's course mode
-        Raises:
-            requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
-            the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
-            does not exist, or is not present in a catalog associated with the customer.
-        """
-        course_details = self.get_content_metadata_for_customer(enterprise_customer_uuid, content_identifier)
-        return price_for_content(course_details)
 
     def get_content_metadata_for_customer(self, enterprise_customer_uuid, content_identifier):
         """

--- a/enterprise_subsidy/apps/api_client/tests/test_enterprise_catalog.py
+++ b/enterprise_subsidy/apps/api_client/tests/test_enterprise_catalog.py
@@ -5,7 +5,8 @@ import ddt
 from django.test import TestCase
 
 from enterprise_subsidy.apps.api_client.enterprise_catalog import EnterpriseCatalogApiClient
-from enterprise_subsidy.apps.subsidy.constants import CENTS_PER_DOLLAR, EDX_PRODUCT_SOURCE
+from enterprise_subsidy.apps.content_metadata.constants import ProductSources
+from enterprise_subsidy.apps.subsidy.constants import CENTS_PER_DOLLAR
 from test_utils.utils import MockResponse
 
 
@@ -168,5 +169,5 @@ class EnterpriseCatalogApiClientTests(TestCase):
             self.enterprise_customer_uuid, self.course_key
         )
         source_name = product_source.get('name') if product_source else 'edX'
-        expected_source = source_name if product_source else EDX_PRODUCT_SOURCE
+        expected_source = source_name if product_source else ProductSources.EDX.value
         assert expected_source == response

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -59,7 +59,7 @@ def product_source_for_content(content_data):
     return EDX_PRODUCT_SOURCE
 
 
-def get_geag_varient_id_for_content(content_data):
+def get_geag_variant_id_for_content(content_data):
     """
     Returns the GEAG ``variant_id`` or ``None``, given a dict of ``content_data``.
     """
@@ -80,7 +80,7 @@ def summary_data_for_content(content_data):
         'source': product_source_for_content(content_data),
         'mode': mode_for_content(content_data),
         'content_price': price_for_content(content_data),
-        'geag_variant_id': get_geag_varient_id_for_content(content_data),
+        'geag_variant_id': get_geag_variant_id_for_content(content_data),
     }
 
 

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -7,14 +7,14 @@ from decimal import Decimal
 
 from enterprise_subsidy.apps.subsidy.constants import CENTS_PER_DOLLAR
 
-from .constants import EDX_PRODUCT_SOURCE, EDX_VERIFIED_COURSE_MODE, EXECUTIVE_EDUCATION_MODE, TWOU_PRODUCT_SOURCE
+from .constants import CourseModes, ProductSources
 
 logger = logging.getLogger(__name__)
 
 
 CONTENT_MODES_BY_PRODUCT_SOURCE = {
-    EDX_PRODUCT_SOURCE: EDX_VERIFIED_COURSE_MODE,
-    TWOU_PRODUCT_SOURCE: EXECUTIVE_EDUCATION_MODE,
+    ProductSources.EDX.value: CourseModes.EDX_VERIFIED.value,
+    ProductSources.TWOU.value: CourseModes.EXECUTIVE_EDUCATION.value,
 }
 
 
@@ -45,7 +45,7 @@ def mode_for_content(content_data):
     Helper to extract the relevant enrollment mode for a piece of content metadata.
     """
     product_source = product_source_for_content(content_data)
-    return CONTENT_MODES_BY_PRODUCT_SOURCE.get(product_source, EDX_VERIFIED_COURSE_MODE)
+    return CONTENT_MODES_BY_PRODUCT_SOURCE.get(product_source, CourseModes.EDX_VERIFIED.value)
 
 
 def product_source_for_content(content_data):
@@ -56,7 +56,7 @@ def product_source_for_content(content_data):
         source_name = product_source.get('name')
         if source_name in CONTENT_MODES_BY_PRODUCT_SOURCE:
             return source_name
-    return EDX_PRODUCT_SOURCE
+    return ProductSources.EDX.value
 
 
 def get_geag_variant_id_for_content(content_data):

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -18,6 +18,7 @@ CONTENT_MODES_BY_PRODUCT_SOURCE = {
     ProductSources.TWOU.value: CourseModes.EXECUTIVE_EDUCATION.value,
 }
 
+
 class ContentMetadataApi:
     """
     An API for interacting with enterprise catalog content metadata.

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -5,6 +5,7 @@ during subsidy redemption and fulfillment.
 import logging
 from decimal import Decimal
 
+from enterprise_subsidy.apps.api_client.enterprise_catalog import EnterpriseCatalogApiClient
 from enterprise_subsidy.apps.subsidy.constants import CENTS_PER_DOLLAR
 
 from .constants import CourseModes, ProductSources
@@ -83,17 +84,60 @@ def summary_data_for_content(content_data):
         'geag_variant_id': get_geag_variant_id_for_content(content_data),
     }
 
+def get_content_summary(enterprise_customer_uuid, content_identifier):
+    """
+    Returns a summary dict some content metadata, makes the client call
+    """
+    course_details = get_content_metadata(enterprise_customer_uuid, content_identifier)
+    return summary_data_for_content(course_details)
 
-def get_content_metadata(content_key=None, content_uuid=None):
+def get_content_metadata(enterprise_customer_uuid, content_identifier):
     """
     Returns a dictionary of content metadata for the given
     identifier.
-    At least one of ``content_key`` or ``content_uuid`` is required.
-    If both are non-null, ``content_key`` will be used as the primary
-    lookup identifier.
     """
-    identifier = content_key or content_uuid
-    if not identifier:
-        # pylint: disable=broad-exception-raised
-        raise Exception('One of content_key or content_uuid is required')
-    raise NotImplementedError
+    catalog_client = EnterpriseCatalogApiClient()
+    return catalog_client.get_content_metadata_for_customer(enterprise_customer_uuid, content_identifier)
+
+
+def get_course_price(enterprise_customer_uuid, content_identifier):
+    """
+    Returns the price of a content as it's defined within the entitlements of the Enterprise Catalog's content
+    metadata record for a piece of content.
+
+    Arguments:
+        enterprise_customer_uuid (UUID): UUID of the customer associated with an enterprise
+        content_identifier (str): **Either** the content UUID or content key identifier for a content record.
+            Note: the content needs to be owned by a catalog associated with the provided customer else this
+            method will throw an HTTPError.
+    Returns:
+        Pricing (list of dicts): Array containing mappings of an individual content's course price associated with
+        a each of it's course mode
+    Raises:
+        requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
+        the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
+        does not exist, or is not present in a catalog associated with the customer.
+    """
+    course_details = get_content_metadata(enterprise_customer_uuid, content_identifier)
+    return price_for_content(course_details)
+
+
+def get_product_source(enterprise_customer_uuid, content_identifier):
+    """
+    Returns the a specific piece of content's product source as it's defined within the content metadata of the
+    Enterprise Catalog service.
+
+    Arguments:
+        enterprise_customer_uuid (UUID): UUID of the customer associated with an enterprise
+        content_identifier (str): **Either** the content UUID or content key identifier for a content record.
+            Note: the content needs to be owned by a catalog associated with the provided customer else this
+            method will throw an HTTPError.
+    Returns:
+        Either `2U` or `edX` based on the content's product source content metadata field
+    Raises:
+        requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
+        the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
+        does not exist, or is not present in a catalog associated with the customer.
+    """
+    course_details = get_content_metadata(enterprise_customer_uuid, content_identifier)
+    return product_source_for_content(course_details)

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -2,6 +2,86 @@
 Python API for gathering content metadata for content identifiers
 during subsidy redemption and fulfillment.
 """
+import logging
+from decimal import Decimal
+
+from enterprise_subsidy.apps.subsidy.constants import CENTS_PER_DOLLAR
+
+from .constants import EDX_PRODUCT_SOURCE, EDX_VERIFIED_COURSE_MODE, EXECUTIVE_EDUCATION_MODE, TWOU_PRODUCT_SOURCE
+
+logger = logging.getLogger(__name__)
+
+
+CONTENT_MODES_BY_PRODUCT_SOURCE = {
+    EDX_PRODUCT_SOURCE: EDX_VERIFIED_COURSE_MODE,
+    TWOU_PRODUCT_SOURCE: EXECUTIVE_EDUCATION_MODE,
+}
+
+
+def price_for_content(content_data):
+    """
+    Helper to return the "official" price for content.
+    The endpoint at ``self.content_metadata_url`` will always return price fields
+    as USD (dollars), possibly as a string or a float.  This method converts
+    those values to USD cents as an integer.
+    """
+    content_price = None
+    if content_data.get('first_enrollable_paid_seat_price'):
+        content_price = content_data['first_enrollable_paid_seat_price']
+
+    if not content_price:
+        enrollment_mode_for_content = mode_for_content(content_data)
+        for entitlement in content_data.get('entitlements', []):
+            if entitlement.get('mode') == enrollment_mode_for_content:
+                content_price = entitlement.get('price')
+
+    if content_price:
+        return int(Decimal(content_price) * CENTS_PER_DOLLAR)
+    return None
+
+
+def mode_for_content(content_data):
+    """
+    Helper to extract the relevant enrollment mode for a piece of content metadata.
+    """
+    product_source = product_source_for_content(content_data)
+    return CONTENT_MODES_BY_PRODUCT_SOURCE.get(product_source, EDX_VERIFIED_COURSE_MODE)
+
+
+def product_source_for_content(content_data):
+    """
+    Helps get the product source string, given a dict of ``content_data``.
+    """
+    if product_source := content_data.get('product_source'):
+        source_name = product_source.get('name')
+        if source_name in CONTENT_MODES_BY_PRODUCT_SOURCE:
+            return source_name
+    return EDX_PRODUCT_SOURCE
+
+
+def get_geag_varient_id_for_content(content_data):
+    """
+    Returns the GEAG ``variant_id`` or ``None``, given a dict of ``content_data``.
+    """
+    variant_id = None
+    if additional_metadata := content_data.get('additional_metadata'):
+        variant_id = additional_metadata.get('variant_id')
+    return variant_id
+
+
+def summary_data_for_content(content_data):
+    """
+    Returns a summary dict specifying the content_uuid, content_key, source, and content_price
+    for a dict of content metadata.
+    """
+    return {
+        'content_uuid': content_data.get('uuid'),
+        'content_key': content_data.get('key'),
+        'source': product_source_for_content(content_data),
+        'mode': mode_for_content(content_data),
+        'content_price': price_for_content(content_data),
+        'geag_variant_id': get_geag_varient_id_for_content(content_data),
+    }
 
 
 def get_content_metadata(content_key=None, content_uuid=None):

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -18,126 +18,133 @@ CONTENT_MODES_BY_PRODUCT_SOURCE = {
     ProductSources.TWOU.value: CourseModes.EXECUTIVE_EDUCATION.value,
 }
 
-
-def price_for_content(content_data):
+class ContentMetadataApi:
     """
-    Helper to return the "official" price for content.
-    The endpoint at ``self.content_metadata_url`` will always return price fields
-    as USD (dollars), possibly as a string or a float.  This method converts
-    those values to USD cents as an integer.
+    An API for interacting with enterprise catalog content metadata.
     """
-    content_price = None
-    if content_data.get('first_enrollable_paid_seat_price'):
-        content_price = content_data['first_enrollable_paid_seat_price']
 
-    if not content_price:
-        enrollment_mode_for_content = mode_for_content(content_data)
-        for entitlement in content_data.get('entitlements', []):
-            if entitlement.get('mode') == enrollment_mode_for_content:
-                content_price = entitlement.get('price')
+    def catalog_client(self):
+        """
+        Get a client for access the Enterprise Catalog service API (enterprise-catalog endpoints).  This contains
+        functions used for fetching full content metadata and pricing data on courses. Cached to reduce the chance of
+        repeated calls to auth.
+        """
+        return EnterpriseCatalogApiClient()
 
-    if content_price:
-        return int(Decimal(content_price) * CENTS_PER_DOLLAR)
-    return None
+    def price_for_content(self, content_data):
+        """
+        Helper to return the "official" price for content.
+        The endpoint at ``self.content_metadata_url`` will always return price fields
+        as USD (dollars), possibly as a string or a float.  This method converts
+        those values to USD cents as an integer.
+        """
+        content_price = None
+        if content_data.get('first_enrollable_paid_seat_price'):
+            content_price = content_data['first_enrollable_paid_seat_price']
 
+        if not content_price:
+            enrollment_mode_for_content = self.mode_for_content(content_data)
+            for entitlement in content_data.get('entitlements', []):
+                if entitlement.get('mode') == enrollment_mode_for_content:
+                    content_price = entitlement.get('price')
 
-def mode_for_content(content_data):
-    """
-    Helper to extract the relevant enrollment mode for a piece of content metadata.
-    """
-    product_source = product_source_for_content(content_data)
-    return CONTENT_MODES_BY_PRODUCT_SOURCE.get(product_source, CourseModes.EDX_VERIFIED.value)
+        if content_price:
+            return int(Decimal(content_price) * CENTS_PER_DOLLAR)
+        return None
 
+    def mode_for_content(self, content_data):
+        """
+        Helper to extract the relevant enrollment mode for a piece of content metadata.
+        """
+        product_source = self.product_source_for_content(content_data)
+        return CONTENT_MODES_BY_PRODUCT_SOURCE.get(product_source, CourseModes.EDX_VERIFIED.value)
 
-def product_source_for_content(content_data):
-    """
-    Helps get the product source string, given a dict of ``content_data``.
-    """
-    if product_source := content_data.get('product_source'):
-        source_name = product_source.get('name')
-        if source_name in CONTENT_MODES_BY_PRODUCT_SOURCE:
-            return source_name
-    return ProductSources.EDX.value
+    def product_source_for_content(self, content_data):
+        """
+        Helps get the product source string, given a dict of ``content_data``.
+        """
+        if product_source := content_data.get('product_source'):
+            source_name = product_source.get('name')
+            if source_name in CONTENT_MODES_BY_PRODUCT_SOURCE:
+                return source_name
+        return ProductSources.EDX.value
 
+    def get_geag_variant_id_for_content(self, content_data):
+        """
+        Returns the GEAG ``variant_id`` or ``None``, given a dict of ``content_data``.
+        """
+        variant_id = None
+        if additional_metadata := content_data.get('additional_metadata'):
+            variant_id = additional_metadata.get('variant_id')
+        return variant_id
 
-def get_geag_variant_id_for_content(content_data):
-    """
-    Returns the GEAG ``variant_id`` or ``None``, given a dict of ``content_data``.
-    """
-    variant_id = None
-    if additional_metadata := content_data.get('additional_metadata'):
-        variant_id = additional_metadata.get('variant_id')
-    return variant_id
+    def summary_data_for_content(self, content_data):
+        """
+        Returns a summary dict specifying the content_uuid, content_key, source, and content_price
+        for a dict of content metadata.
+        """
+        return {
+            'content_uuid': content_data.get('uuid'),
+            'content_key': content_data.get('key'),
+            'source': self.product_source_for_content(content_data),
+            'mode': self.mode_for_content(content_data),
+            'content_price': self.price_for_content(content_data),
+            'geag_variant_id': self.get_geag_variant_id_for_content(content_data),
+        }
 
+    def get_content_summary(self, enterprise_customer_uuid, content_identifier):
+        """
+        Returns a summary dict some content metadata, makes the client call
+        """
+        course_details = self.catalog_client().get_content_metadata_for_customer(
+            enterprise_customer_uuid,
+            content_identifier
+        )
+        return self.summary_data_for_content(course_details)
 
-def summary_data_for_content(content_data):
-    """
-    Returns a summary dict specifying the content_uuid, content_key, source, and content_price
-    for a dict of content metadata.
-    """
-    return {
-        'content_uuid': content_data.get('uuid'),
-        'content_key': content_data.get('key'),
-        'source': product_source_for_content(content_data),
-        'mode': mode_for_content(content_data),
-        'content_price': price_for_content(content_data),
-        'geag_variant_id': get_geag_variant_id_for_content(content_data),
-    }
+    def get_course_price(self, enterprise_customer_uuid, content_identifier):
+        """
+        Returns the price of a content as it's defined within the entitlements of the Enterprise Catalog's content
+        metadata record for a piece of content.
 
-def get_content_summary(enterprise_customer_uuid, content_identifier):
-    """
-    Returns a summary dict some content metadata, makes the client call
-    """
-    course_details = get_content_metadata(enterprise_customer_uuid, content_identifier)
-    return summary_data_for_content(course_details)
+        Arguments:
+            enterprise_customer_uuid (UUID): UUID of the customer associated with an enterprise
+            content_identifier (str): **Either** the content UUID or content key identifier for a content record.
+                Note: the content needs to be owned by a catalog associated with the provided customer else this
+                method will throw an HTTPError.
+        Returns:
+            Pricing (list of dicts): Array containing mappings of an individual content's course price associated with
+            a each of it's course mode
+        Raises:
+            requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
+            the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
+            does not exist, or is not present in a catalog associated with the customer.
+        """
+        course_details = self.catalog_client().get_content_metadata_for_customer(
+            enterprise_customer_uuid,
+            content_identifier
+        )
+        return self.price_for_content(course_details)
 
-def get_content_metadata(enterprise_customer_uuid, content_identifier):
-    """
-    Returns a dictionary of content metadata for the given
-    identifier.
-    """
-    catalog_client = EnterpriseCatalogApiClient()
-    return catalog_client.get_content_metadata_for_customer(enterprise_customer_uuid, content_identifier)
+    def get_product_source(self, enterprise_customer_uuid, content_identifier):
+        """
+        Returns the a specific piece of content's product source as it's defined within the content metadata of the
+        Enterprise Catalog service.
 
-
-def get_course_price(enterprise_customer_uuid, content_identifier):
-    """
-    Returns the price of a content as it's defined within the entitlements of the Enterprise Catalog's content
-    metadata record for a piece of content.
-
-    Arguments:
-        enterprise_customer_uuid (UUID): UUID of the customer associated with an enterprise
-        content_identifier (str): **Either** the content UUID or content key identifier for a content record.
-            Note: the content needs to be owned by a catalog associated with the provided customer else this
-            method will throw an HTTPError.
-    Returns:
-        Pricing (list of dicts): Array containing mappings of an individual content's course price associated with
-        a each of it's course mode
-    Raises:
-        requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
-        the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
-        does not exist, or is not present in a catalog associated with the customer.
-    """
-    course_details = get_content_metadata(enterprise_customer_uuid, content_identifier)
-    return price_for_content(course_details)
-
-
-def get_product_source(enterprise_customer_uuid, content_identifier):
-    """
-    Returns the a specific piece of content's product source as it's defined within the content metadata of the
-    Enterprise Catalog service.
-
-    Arguments:
-        enterprise_customer_uuid (UUID): UUID of the customer associated with an enterprise
-        content_identifier (str): **Either** the content UUID or content key identifier for a content record.
-            Note: the content needs to be owned by a catalog associated with the provided customer else this
-            method will throw an HTTPError.
-    Returns:
-        Either `2U` or `edX` based on the content's product source content metadata field
-    Raises:
-        requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
-        the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
-        does not exist, or is not present in a catalog associated with the customer.
-    """
-    course_details = get_content_metadata(enterprise_customer_uuid, content_identifier)
-    return product_source_for_content(course_details)
+        Arguments:
+            enterprise_customer_uuid (UUID): UUID of the customer associated with an enterprise
+            content_identifier (str): **Either** the content UUID or content key identifier for a content record.
+                Note: the content needs to be owned by a catalog associated with the provided customer else this
+                method will throw an HTTPError.
+        Returns:
+            Either `2U` or `edX` based on the content's product source content metadata field
+        Raises:
+            requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
+            the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
+            does not exist, or is not present in a catalog associated with the customer.
+        """
+        course_details = self.catalog_client().get_content_metadata_for_customer(
+            enterprise_customer_uuid,
+            content_identifier
+        )
+        return self.product_source_for_content(course_details)

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -72,6 +72,7 @@ class ContentMetadataApi:
     def get_geag_variant_id_for_content(self, content_data):
         """
         Returns the GEAG ``variant_id`` or ``None``, given a dict of ``content_data``.
+        In the GEAG system a ``variant_id`` is aka a ``product_id``.
         """
         variant_id = None
         if additional_metadata := content_data.get('additional_metadata'):

--- a/enterprise_subsidy/apps/content_metadata/constants.py
+++ b/enterprise_subsidy/apps/content_metadata/constants.py
@@ -1,7 +1,19 @@
+from enum import Enum
+
 """
 Constants about content metadata.
 """
-EDX_PRODUCT_SOURCE = "edX"
-TWOU_PRODUCT_SOURCE = "2u"
-EXECUTIVE_EDUCATION_MODE = "paid-executive-education"
-EDX_VERIFIED_COURSE_MODE = "verified"
+
+class ProductSources(Enum):
+    """
+    Content metadata product_source keys
+    """
+    EDX = "edX"  # e.g. OCM courses
+    TWOU = "2u"  # e.g. ExecEd courses
+
+class CourseModes(Enum):
+    """
+    Content metadata course mode keys
+    """
+    EDX_VERIFIED = "verified"  # e.g. edX Verified Courses
+    EXECUTIVE_EDUCATION = "paid-executive-education"  # e.g. ExecEd courses

--- a/enterprise_subsidy/apps/content_metadata/constants.py
+++ b/enterprise_subsidy/apps/content_metadata/constants.py
@@ -3,12 +3,14 @@ Constants about content metadata.
 """
 from enum import Enum
 
+
 class ProductSources(Enum):
     """
     Content metadata product_source keys
     """
     EDX = "edX"  # e.g. OCM courses
     TWOU = "2u"  # e.g. ExecEd courses
+
 
 class CourseModes(Enum):
     """

--- a/enterprise_subsidy/apps/content_metadata/constants.py
+++ b/enterprise_subsidy/apps/content_metadata/constants.py
@@ -1,8 +1,7 @@
-from enum import Enum
-
 """
 Constants about content metadata.
 """
+from enum import Enum
 
 class ProductSources(Enum):
     """

--- a/enterprise_subsidy/apps/content_metadata/constants.py
+++ b/enterprise_subsidy/apps/content_metadata/constants.py
@@ -1,0 +1,7 @@
+"""
+Constants about content metadata.
+"""
+EDX_PRODUCT_SOURCE = "edX"
+TWOU_PRODUCT_SOURCE = "2u"
+EXECUTIVE_EDUCATION_MODE = "paid-executive-education"
+EDX_VERIFIED_COURSE_MODE = "verified"

--- a/enterprise_subsidy/apps/content_metadata/tests/test_api.py
+++ b/enterprise_subsidy/apps/content_metadata/tests/test_api.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 import ddt
 from django.test import TestCase
 
-from enterprise_subsidy.apps.content_metadata.api import get_course_price, get_product_source
+from enterprise_subsidy.apps.content_metadata.api import ContentMetadataApi
 from enterprise_subsidy.apps.content_metadata.constants import ProductSources
 from enterprise_subsidy.apps.subsidy.constants import CENTS_PER_DOLLAR
 from test_utils.utils import MockResponse
@@ -19,6 +19,7 @@ class ContentMetadataApiTests(TestCase):
     def setUpTestData(cls):
         super().setUpTestData()
 
+        cls.content_metadata_api = ContentMetadataApi()
         cls.enterprise_customer_uuid = uuid4()
         cls.user_id = 3
         cls.user_email = 'ayy@lmao.com'
@@ -128,7 +129,7 @@ class ContentMetadataApiTests(TestCase):
         mocked_data['product_source'] = product_source
         mocked_data['entitlements'] = entitlements
         mock_oauth_client.return_value.get.return_value = MockResponse(mocked_data, 200)
-        price_in_cents = get_course_price(
+        price_in_cents = self.content_metadata_api.get_course_price(
             self.enterprise_customer_uuid, self.course_key
         )
         assert price_in_cents == float(entitlements[0].get('price')) * CENTS_PER_DOLLAR
@@ -150,7 +151,7 @@ class ContentMetadataApiTests(TestCase):
         mocked_data = self.course_metadata.copy()
         mocked_data['product_source'] = product_source
         mock_oauth_client.return_value.get.return_value = MockResponse(mocked_data, 200)
-        response = get_product_source(
+        response = self.content_metadata_api.get_product_source(
             self.enterprise_customer_uuid, self.course_key
         )
         source_name = product_source.get('name') if product_source else 'edX'

--- a/enterprise_subsidy/apps/subsidy/constants.py
+++ b/enterprise_subsidy/apps/subsidy/constants.py
@@ -24,8 +24,3 @@ PERMISSION_CAN_READ_CONTENT_METADATA = "subsidy.can_read_metadata"
 # Provide a convenience permission which should never be granted.  This is helpful for being explicit when overriding
 # `get_permission_required()`.
 PERMISSION_NOT_GRANTED = 'subsidy.not_granted'
-
-EDX_PRODUCT_SOURCE = "edX"
-TWOU_PRODUCT_SOURCE = "2u"
-EXECUTIVE_EDUCATION_MODE = "paid-executive-education"
-EDX_VERIFIED_COURSE_MODE = "verified"

--- a/enterprise_subsidy/apps/subsidy/tests/test_api.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_api.py
@@ -66,8 +66,8 @@ class CanRedeemTestCase(TestCase):
             enterprise_customer_uuid=self.enterprise_customer_uuid,
             starting_balance=100000,
         )
-        self.subsidy.catalog_client = mock.MagicMock()
-        self.subsidy.catalog_client.get_course_price.return_value = 19998
+        self.subsidy.content_metadata_api = mock.MagicMock()
+        self.subsidy.content_metadata_api().get_course_price.return_value = 19998
         self.lms_user_id = 42
         self.content_key = 'some-content-key'
         super().setUp()


### PR DESCRIPTION
### Description

- Breaking out some of the work in https://github.com/openedx/enterprise-subsidy/pull/51
- refactor some of the content metadata stuff
- add geag variant id capture

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
