### PR TITLE
feat: add create and delete endpoint for subsidies

### DIFF
--- a/enterprise_subsidy/apps/api/v1/exceptions.py
+++ b/enterprise_subsidy/apps/api/v1/exceptions.py
@@ -1,0 +1,21 @@
+"""
+Custom exceptions for the Subsidy API
+"""
+from rest_framework.exceptions import APIException
+
+
+class ServerError(APIException):
+    """
+    A custom exception class for server errors.
+    This class is a subclass of the DRF APIException class, and is designed
+    to be raised when an unexpected error occurs in the subsidies service.
+    """
+    status_code = 500
+    default_detail = 'encountered an unexpected error in subsidies service'
+    default_code = 'server_error'
+
+    def __init__(self, *args, **kwargs):
+        self.code = kwargs['code']
+        self.developer_message = kwargs.pop('developer_message', None)
+        self.user_message = kwargs.pop('user_message', None)
+        super().__init__(*args, **kwargs)

--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -29,6 +29,7 @@ class SubsidySerializer(serializers.ModelSerializer):
             "reference_id",
             "reference_type",
             "current_balance",
+            "starting_balance",
             "internal_only",
             "revenue_category",
             # In the MVP implementation, there are only learner_credit subsidies.  Uncomment after subscription
@@ -136,4 +137,33 @@ class ExceptionSerializer(serializers.Serializer):
     """
     detail = serializers.CharField(
         help_text="A description of the reason for the error.",
+    )
+
+
+# pylint: disable=abstract-method
+class SubsidyCreationRequestSerializer(serializers.Serializer):
+    """
+    Serializer for creating a subsidy request
+    """
+    reference_id = serializers.CharField(
+        required=True,
+        help_text="Reference id",
+    )
+    default_title = serializers.CharField(
+        required=True,
+    )
+    default_enterprise_customer_uuid = serializers.UUIDField(
+        required=True,
+    )
+    default_unit = serializers.CharField(
+        required=True,
+    )
+    default_starting_balance = serializers.IntegerField(
+        required=True,
+    )
+    default_revenue_category = serializers.CharField(
+        required=True,
+    )
+    default_internal_only = serializers.BooleanField(
+        required=True,
     )

--- a/enterprise_subsidy/apps/subsidy/constants.py
+++ b/enterprise_subsidy/apps/subsidy/constants.py
@@ -21,6 +21,7 @@ PERMISSION_CAN_CREATE_TRANSACTIONS = "subsidy.can_create_transactions"
 PERMISSION_CAN_READ_SUBSIDIES = "subsidy.can_read_subsidies"
 PERMISSION_CAN_READ_TRANSACTIONS = "subsidy.can_read_transactions"
 PERMISSION_CAN_READ_CONTENT_METADATA = "subsidy.can_read_metadata"
+PERMISSION_CAN_WRITE_SUBSIDIES = "subsidy.can_write_subsidies"
 # Provide a convenience permission which should never be granted.  This is helpful for being explicit when overriding
 # `get_permission_required()`.
 PERMISSION_NOT_GRANTED = 'subsidy.not_granted'

--- a/enterprise_subsidy/apps/subsidy/rules.py
+++ b/enterprise_subsidy/apps/subsidy/rules.py
@@ -14,7 +14,8 @@ from enterprise_subsidy.apps.subsidy.constants import (
     PERMISSION_CAN_CREATE_TRANSACTIONS,
     PERMISSION_CAN_READ_CONTENT_METADATA,
     PERMISSION_CAN_READ_SUBSIDIES,
-    PERMISSION_CAN_READ_TRANSACTIONS
+    PERMISSION_CAN_READ_TRANSACTIONS,
+    PERMISSION_CAN_WRITE_SUBSIDIES
 )
 from enterprise_subsidy.apps.subsidy.models import EnterpriseSubsidyRoleAssignment
 
@@ -106,3 +107,4 @@ rules.add_perm(PERMISSION_CAN_CREATE_TRANSACTIONS, has_operator_level_access)
 rules.add_perm(PERMISSION_CAN_READ_SUBSIDIES, has_admin_level_access)
 rules.add_perm(PERMISSION_CAN_READ_TRANSACTIONS, has_learner_level_access)
 rules.add_perm(PERMISSION_CAN_READ_CONTENT_METADATA, has_learner_level_access)
+rules.add_perm(PERMISSION_CAN_WRITE_SUBSIDIES, has_operator_level_access)


### PR DESCRIPTION
* POST /api/v1/subsidies/
* DELETE /api/v1/subsidies/{uuid}/

ent-6998

### Description
Adds the create and delete endpoint for subsides, using drf-spectacular to document the intended use cases

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
