### PR TITLE
refactor: `learner_id` -> `lms_user_id`

### DIFF
--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -668,11 +668,11 @@ class TransactionViewSetTests(APITestBase):
             },
             "expected_response_uuids": [],
         },
-        # Test filtering by learner_id.
+        # Test filtering by lms_user_id.
         {
             "request_query_params": {
                 "subsidy_uuid": APITestBase.subsidy_1_uuid,
-                "learner_id": STATIC_LMS_USER_ID,
+                "lms_user_id": STATIC_LMS_USER_ID,
             },
             "expected_response_uuids": [
                 APITestBase.subsidy_1_transaction_1_uuid,
@@ -682,7 +682,7 @@ class TransactionViewSetTests(APITestBase):
         {
             "request_query_params": {
                 "subsidy_uuid": APITestBase.subsidy_1_uuid,
-                "learner_id": -1,
+                "lms_user_id": -1,
             },
             "expected_response_uuids": [],
         },
@@ -825,7 +825,7 @@ class TransactionViewSetTests(APITestBase):
         self.set_up_operator()
         post_data = {
             "subsidy_uuid": str(self.subsidy_1.uuid),
-            "learner_id": 1234,
+            "lms_user_id": 1234,
             "content_key": "course-v1:edX-test-course",
             "subsidy_access_policy_uuid": str(uuid.uuid4()),
         }
@@ -836,7 +836,7 @@ class TransactionViewSetTests(APITestBase):
         # TODO: make this assertion more specific once we hookup the idempotency_key to the request body.
         assert create_response_data["idempotency_key"]
         assert create_response_data["content_key"] == post_data["content_key"]
-        assert create_response_data["lms_user_id"] == post_data["learner_id"]
+        assert create_response_data["lms_user_id"] == post_data["lms_user_id"]
         assert create_response_data["subsidy_access_policy_uuid"] == post_data["subsidy_access_policy_uuid"]
         self.assertDictEqual(create_response_data["metadata"], {})
         assert create_response_data["unit"] == self.subsidy_1.ledger.unit
@@ -886,7 +886,7 @@ class TransactionViewSetTests(APITestBase):
             }
         post_data = {
             "subsidy_uuid": str(self.subsidy_1.uuid),
-            "learner_id": 1234,
+            "lms_user_id": 1234,
             "content_key": "course-v1:edX-test-course",
             "subsidy_access_policy_uuid": str(uuid.uuid4()),
             "metadata": tx_metadata
@@ -898,7 +898,7 @@ class TransactionViewSetTests(APITestBase):
         # TODO: make this assertion more specific once we hookup the idempotency_key to the request body.
         assert create_response_data["idempotency_key"]
         assert create_response_data["content_key"] == post_data["content_key"]
-        assert create_response_data["lms_user_id"] == post_data["learner_id"]
+        assert create_response_data["lms_user_id"] == post_data["lms_user_id"]
         assert create_response_data["subsidy_access_policy_uuid"] == post_data["subsidy_access_policy_uuid"]
         self.assertDictEqual(create_response_data["metadata"], tx_metadata)
         assert create_response_data["unit"] == self.subsidy_1.ledger.unit
@@ -929,7 +929,7 @@ class TransactionViewSetTests(APITestBase):
         self.set_up_operator()
         post_data = {
             "subsidy_uuid": str(self.subsidy_1.uuid),
-            "learner_id": 1234,
+            "lms_user_id": 1234,
             "content_key": "course-v1:edX-test-course",
             "subsidy_access_policy_uuid": str(uuid.uuid4()),
         }
@@ -951,7 +951,7 @@ class TransactionViewSetTests(APITestBase):
         url = reverse("api:v1:transaction-list")
         post_data = {
             "subsidy_uuid": str(self.subsidy_1.uuid),
-            "learner_id": 1234,
+            "lms_user_id": 1234,
             "content_key": "course-v1:edX-test-course",
             "subsidy_access_policy_uuid": str(uuid.uuid4()),
         }
@@ -971,7 +971,7 @@ class TransactionViewSetTests(APITestBase):
         mock_price_for_content.return_value = 10000000  # Wow! that's pricey!
         post_data = {
             "subsidy_uuid": str(self.subsidy_1.uuid),
-            "learner_id": 1234,
+            "lms_user_id": 1234,
             "content_key": "course-v1:edX-test-course",
             "subsidy_access_policy_uuid": str(uuid.uuid4()),
         }
@@ -992,7 +992,7 @@ class TransactionViewSetTests(APITestBase):
         )
         post_data = {
             "subsidy_uuid": str(self.subsidy_1.uuid),
-            "learner_id": 1234,
+            "lms_user_id": 1234,
             "content_key": "course-v1:edX-test-course",
             "subsidy_access_policy_uuid": str(uuid.uuid4()),
         }
@@ -1016,7 +1016,7 @@ class TransactionViewSetTests(APITestBase):
         test_lms_user_id = 1234
         post_data = {
             "subsidy_uuid": str(self.subsidy_1.uuid),
-            "learner_id": test_lms_user_id,
+            "lms_user_id": test_lms_user_id,
             "content_key": test_content_key,
             "subsidy_access_policy_uuid": str(uuid.uuid4()),
         }
@@ -1035,7 +1035,7 @@ class TransactionViewSetTests(APITestBase):
 
         post_data = {
             "subsidy_uuid": str(self.subsidy_1.uuid) + "a",  # Make uuid invalid.
-            "learner_id": 1234,
+            "lms_user_id": 1234,
             "content_key": "course-v1:edX-test-course",
             "subsidy_access_policy_uuid": str(uuid.uuid4()),
         }
@@ -1053,7 +1053,7 @@ class TransactionViewSetTests(APITestBase):
 
         post_data = {
             "subsidy_uuid": str(self.subsidy_1.uuid),
-            "learner_id": 1234,
+            "lms_user_id": 1234,
             "content_key": "course-v1:edX-test-course",
             "subsidy_access_policy_uuid": str(uuid.uuid4()) + "a",  # Make uuid invalid.
         }
@@ -1061,7 +1061,7 @@ class TransactionViewSetTests(APITestBase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "Error" in response.json()
 
-    @ddt.data("subsidy_uuid", "learner_id", "content_key", "subsidy_access_policy_uuid")
+    @ddt.data("subsidy_uuid", "lms_user_id", "content_key", "subsidy_access_policy_uuid")
     def test_create_missing_inputs(self, missing_post_arg):
         """
         Test create Transaction, 4xx due to missing inputs.
@@ -1072,7 +1072,7 @@ class TransactionViewSetTests(APITestBase):
 
         post_data = {
             "subsidy_uuid": str(self.subsidy_1.uuid),
-            "learner_id": 1234,
+            "lms_user_id": 1234,
             "content_key": "course-v1:edX-test-course",
             "subsidy_access_policy_uuid": str(uuid.uuid4()),
         }

--- a/enterprise_subsidy/apps/api/v1/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v1/views/transaction.py
@@ -135,11 +135,11 @@ class TransactionViewSet(
         return self.request.query_params.get("content_key")
 
     @property
-    def requested_learner_id(self):
+    def requested_lms_user_id(self):
         """
-        Fetch the learner_id from the URL query parameters.
+        Fetch the lms_user_id from the URL query parameters.
         """
-        return self.request.query_params.get("learner_id")
+        return self.request.query_params.get("lms_user_id")
 
     @property
     def requested_enterprise_customer_uuid(self):
@@ -240,8 +240,8 @@ class TransactionViewSet(
             request_based_kwargs.update({"uuid": self.requested_transaction_uuid})
         if self.requested_subsidy_access_policy_uuid:
             request_based_kwargs.update({"subsidy_access_policy_uuid": self.requested_subsidy_access_policy_uuid})
-        if self.requested_learner_id:
-            request_based_kwargs.update({"lms_user_id": self.requested_learner_id})
+        if self.requested_lms_user_id:
+            request_based_kwargs.update({"lms_user_id": self.requested_lms_user_id})
         if self.requested_content_key:
             request_based_kwargs.update({"content_key": self.requested_content_key})
 
@@ -310,7 +310,7 @@ class TransactionViewSet(
               customer UUID.
         - ``subsidy_access_policy_uuid`` (query param, optional):
               Filter the output to only include transactions created by the given subsidy access policy UUID.
-        - ``learner_id`` (query_param, optional):
+        - ``lms_user_id`` (query_param, optional):
               Filter the output to only include transactions assoicated with the given learner ID.
         - ``content_key`` (query_param, optional):
               Filter the output to only include transactions assoicated with the given content_key.
@@ -384,7 +384,7 @@ class TransactionViewSet(
         Request Arguments:
         - ``subsidy_uuid`` (POST data, required):
               The uuid (primary key) of the subsidy for which transactions should be created.
-        - ``learner_id`` (POST data, required):
+        - ``lms_user_id`` (POST data, required):
               The user for whom the transaction is written and for which a fulfillment should occur.
         - ``content_key`` (POST data, required):
               The content for which a fulfillment is created.
@@ -423,16 +423,16 @@ class TransactionViewSet(
                      }
         """
         subsidy_uuid = request.data.get("subsidy_uuid")
-        learner_id = request.data.get("learner_id")
+        lms_user_id = request.data.get("lms_user_id")
         content_key = request.data.get("content_key")
         subsidy_access_policy_uuid = request.data.get("subsidy_access_policy_uuid")
         metadata = request.data.get("metadata")
-        if not all([subsidy_uuid, learner_id, content_key, subsidy_access_policy_uuid]):
+        if not all([subsidy_uuid, lms_user_id, content_key, subsidy_access_policy_uuid]):
             return Response(
                 {
                     "Error": (
                         "One or more required fields were not provided in the request body: "
-                        "[subsidy_uuid, learner_id, content_key, subsidy_access_policy_uuid]"
+                        "[subsidy_uuid, lms_user_id, content_key, subsidy_access_policy_uuid]"
                     )
                 },
                 status=status.HTTP_400_BAD_REQUEST,
@@ -454,7 +454,7 @@ class TransactionViewSet(
             )
         try:
             transaction, created = subsidy.redeem(
-                learner_id,
+                lms_user_id,
                 content_key,
                 subsidy_access_policy_uuid,
                 metadata=metadata

--- a/enterprise_subsidy/apps/api_client/enterprise.py
+++ b/enterprise_subsidy/apps/api_client/enterprise.py
@@ -65,11 +65,11 @@ class EnterpriseApiClient(BaseOAuthClient):
                 )
             raise exc
 
-    def enroll(self, learner_id, course_run_key, ledger_transaction):
+    def enroll(self, lms_user_id, course_run_key, ledger_transaction):
         """
         Creates a single subsidy enrollment in a course run for an enterprise learner from a subsidy transaction.
         Arguments:
-            learner_id (int): lms_user_id of the learner to be enrolled
+            lms_user_id (int): lms_user_id of the learner to be enrolled
             course_run_key (str): Course run key value of the course run to be enrolled in
             ledger_transaction (openedx_ledger.models.Transaction): the Transaction returned from the ledger
         Returns:
@@ -82,7 +82,7 @@ class EnterpriseApiClient(BaseOAuthClient):
                 If enrollment response contained an unexpected output, such as missing data.
         """
         enrollments_info = [{
-            'user_id': learner_id,
+            'user_id': lms_user_id,
             'course_run_key': course_run_key,
             'transaction_id': str(ledger_transaction.uuid),
         }]

--- a/enterprise_subsidy/apps/fulfillment/api.py
+++ b/enterprise_subsidy/apps/fulfillment/api.py
@@ -8,7 +8,7 @@ from enterprise_subsidy.apps.content_metadata import api as content_metadata_api
 from .constants import EXEC_ED_2U_COURSE_TYPES, OPEN_COURSES_COURSE_TYPES
 
 
-def create_fulfillment(subsidy_uuid, learner_id, content_key, **metadata):
+def create_fulfillment(subsidy_uuid, lms_user_id, content_key, **metadata):
     """
     Creates a fulfillment.
     """

--- a/enterprise_subsidy/apps/subsidy/tests/test_models.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_models.py
@@ -111,23 +111,23 @@ class SubsidyModelRedemptionTestCase(TestCase):
         """
         Tests that get_redemption appropriately filters by learner and content identifiers.
         """
-        alice_learner_id, bob_learner_id = (23, 42)
+        alice_lms_user_id, bob_lms_user_id = (23, 42)
         learner_content_pairs = list(product(
-            (alice_learner_id, bob_learner_id),
+            (alice_lms_user_id, bob_lms_user_id),
             ('science-content-key', 'art-content-key'),
         ))
-        for learner_id, content_key in learner_content_pairs:
+        for lms_user_id, content_key in learner_content_pairs:
             TransactionFactory.create(
                 state=TransactionStateChoices.COMMITTED,
                 quantity=-1000,
                 ledger=self.subsidy.ledger,
-                lms_user_id=learner_id,
+                lms_user_id=lms_user_id,
                 content_key=content_key
             )
 
-        for learner_id, content_key in learner_content_pairs:
-            transaction = self.subsidy.get_redemption(learner_id, content_key)
-            self.assertEqual(transaction.lms_user_id, learner_id)
+        for lms_user_id, content_key in learner_content_pairs:
+            transaction = self.subsidy.get_redemption(lms_user_id, content_key)
+            self.assertEqual(transaction.lms_user_id, lms_user_id)
             self.assertEqual(transaction.content_key, content_key)
             self.assertEqual(transaction.quantity, -1000)
             self.assertEqual(transaction.state, TransactionStateChoices.COMMITTED)
@@ -167,7 +167,7 @@ class SubsidyModelRedemptionTestCase(TestCase):
         Test Subsidy.redeem() happy path (i.e. the redemption/transaction does not already exist, and calling redeem()
         creates one).
         """
-        learner_id = 1
+        lms_user_id = 1
         content_key = "course-v1:edX+test+course"
         subsidy_access_policy_uuid = str(uuid4())
         mock_enterprise_fulfillment_uuid = str(uuid4())
@@ -175,7 +175,7 @@ class SubsidyModelRedemptionTestCase(TestCase):
         mock_price_for_content.return_value = mock_content_price
         mock_enterprise_client.enroll.return_value = mock_enterprise_fulfillment_uuid
         new_transaction, transaction_created = self.subsidy.redeem(
-            learner_id,
+            lms_user_id,
             content_key,
             subsidy_access_policy_uuid
         )
@@ -189,7 +189,7 @@ class SubsidyModelRedemptionTestCase(TestCase):
         """
         Test Subsidy.redeem() happy path with additional metadata
         """
-        learner_id = 1
+        lms_user_id = 1
         content_key = "course-v1:edX+test+course"
         subsidy_access_policy_uuid = str(uuid4())
         mock_enterprise_fulfillment_uuid = str(uuid4())
@@ -201,7 +201,7 @@ class SubsidyModelRedemptionTestCase(TestCase):
             'geag_last_name': 'Kerabatsos',
         }
         new_transaction, transaction_created = self.subsidy.redeem(
-            learner_id,
+            lms_user_id,
             content_key,
             subsidy_access_policy_uuid,
             metadata=tx_metadata


### PR DESCRIPTION
This is a mostly* no-op change to make the code consistently refer to the user identifier using the same name.

\* = the REST API endpoint to list transactions has been changed to require an "lms_user_id" query parameter instead of "learner_id".  This fixes an integration bug cased by enterprise-access passing "lms_user_id" when it was not accepted.

ENT-6988

Related PRs:
* https://github.com/openedx/enterprise-access/pull/138
* https://github.com/openedx/edx-enterprise-subsidy-client/pull/16