### PR TITLE
feat: redemption metadata

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -74,6 +74,7 @@ class TransactionSerializer(serializers.ModelSerializer):
         help_text="The unit in which this transaction's quantity is denominated."
     )
     reversal = ReversalSerializer(read_only=True)
+    metadata = serializers.SerializerMethodField()
 
     class Meta:
         """
@@ -96,6 +97,12 @@ class TransactionSerializer(serializers.ModelSerializer):
             "reversal",  # Note that the `reversal` field is found via reverse relationship.
             "external_reference",  # Note that the `external_reference` field is found via reverse relationship.
         ]
+
+    def get_metadata(self, obj):
+        """
+        Properly serialize this json/dict
+        """
+        return obj.metadata
 
     def get_unit(self, obj):
         """

--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -74,6 +74,7 @@ class TransactionSerializer(serializers.ModelSerializer):
         help_text="The unit in which this transaction's quantity is denominated."
     )
     reversal = ReversalSerializer(read_only=True)
+    # http://web.archive.org/web/20230427144910/https://romansorin.com/blog/using-djangos-jsonfield-you-probably-dont-need-it-heres-why
     metadata = serializers.SerializerMethodField()
 
     class Meta:
@@ -101,6 +102,7 @@ class TransactionSerializer(serializers.ModelSerializer):
     def get_metadata(self, obj):
         """
         Properly serialize this json/dict
+        http://web.archive.org/web/20230427144910/https://romansorin.com/blog/using-djangos-jsonfield-you-probably-dont-need-it-heres-why
         """
         return obj.metadata
 

--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -900,7 +900,6 @@ class TransactionViewSetTests(APITestBase):
         assert create_response_data["content_key"] == post_data["content_key"]
         assert create_response_data["lms_user_id"] == post_data["learner_id"]
         assert create_response_data["subsidy_access_policy_uuid"] == post_data["subsidy_access_policy_uuid"]
-        assert isinstance(create_response_data["metadata"], dict)
         self.assertDictEqual(create_response_data["metadata"], tx_metadata)
         assert create_response_data["unit"] == self.subsidy_1.ledger.unit
         assert create_response_data["quantity"] < 0  # No need to be exact at this time, I'm just testing create works.

--- a/enterprise_subsidy/apps/api/v1/views/subsidy.py
+++ b/enterprise_subsidy/apps/api/v1/views/subsidy.py
@@ -244,7 +244,7 @@ class SubsidyViewSet(
                         detail="Multiple subsidies with given reference_id found.",
                         user_message="Multiple subsidies with given reference_id found.",
                     ) from exc
-            except Exception as exc:  # pylint: disable=broad-except
+            except Exception as exc:
                 raise ServerError(
                     code="could_not_create_subsidy",
                     detail=f"Subsidy could not be created: {exc}",

--- a/enterprise_subsidy/apps/api/v1/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v1/views/transaction.py
@@ -426,6 +426,7 @@ class TransactionViewSet(
         learner_id = request.data.get("learner_id")
         content_key = request.data.get("content_key")
         subsidy_access_policy_uuid = request.data.get("subsidy_access_policy_uuid")
+        metadata = request.data.get("metadata")
         if not all([subsidy_uuid, learner_id, content_key, subsidy_access_policy_uuid]):
             return Response(
                 {
@@ -452,7 +453,7 @@ class TransactionViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
         try:
-            transaction, created = subsidy.redeem(learner_id, content_key, subsidy_access_policy_uuid)
+            transaction, created = subsidy.redeem(learner_id, content_key, subsidy_access_policy_uuid, metadata)
         except LedgerLockAttemptFailed as exc:
             logger.error(exc)
             return Response(

--- a/enterprise_subsidy/apps/api/v1/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v1/views/transaction.py
@@ -453,7 +453,12 @@ class TransactionViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
         try:
-            transaction, created = subsidy.redeem(learner_id, content_key, subsidy_access_policy_uuid, metadata)
+            transaction, created = subsidy.redeem(
+                learner_id,
+                content_key,
+                subsidy_access_policy_uuid,
+                metadata=metadata
+            )
         except LedgerLockAttemptFailed as exc:
             logger.error(exc)
             return Response(


### PR DESCRIPTION
### Description

- Adds the ability to pass metadata into the final transaction.
- https://2u-internal.atlassian.net/browse/ENT-7068
- https://github.com/openedx/enterprise-access/pull/134

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
