### PR TITLE
feat: v2 transaction create API now supports metadata field input

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -135,6 +135,11 @@ class TransactionCreationRequestSerializer(serializers.ModelSerializer):
     """
     Serializer for creating instances of the `Transaction` model.
     """
+    metadata = serializers.JSONField(
+        help_text="Any additional metadata that a client may want to associate with this Transaction instance.",
+        required=False,
+        allow_null=True,
+    )
 
     class Meta:
         """
@@ -146,6 +151,7 @@ class TransactionCreationRequestSerializer(serializers.ModelSerializer):
             'lms_user_id',
             'content_key',
             'subsidy_access_policy_uuid',
+            'metadata',
         ]
         # Override lms_user_id, content_key, and subsidy_access_policy_uuid to each be required;
         # their model field definitions have `required=False`.
@@ -185,6 +191,7 @@ class TransactionCreationRequestSerializer(serializers.ModelSerializer):
                 validated_data['content_key'],
                 validated_data['subsidy_access_policy_uuid'],
                 idempotency_key=validated_data.get('idempotency_key'),
+                metadata=validated_data.get('metadata'),
             )
         except LedgerLockAttemptFailed as exc:
             logger.exception(

--- a/enterprise_subsidy/apps/api/v2/tests/test_transaction_views.py
+++ b/enterprise_subsidy/apps/api/v2/tests/test_transaction_views.py
@@ -457,6 +457,7 @@ class TransactionAdminCreateViewTests(APITestBase):
             self.content_key_2,
             uuid.UUID(self.subsidy_access_policy_1_uuid),
             idempotency_key='my-idempotency-key',
+            metadata=None,
         )
         assert response.json() == {'detail': 'Attempt to lock the Ledger failed, please try again.'}
 
@@ -558,6 +559,9 @@ class TransactionAdminCreateViewTests(APITestBase):
             'content_key': self.content_key_1,
             'subsidy_access_policy_uuid': self.subsidy_access_policy_1_uuid,
             'idempotency_key': 'my-idempotency-key',
+            'metadata': {
+                'foo': 'bar',
+            },
         }
 
         response = self.client.post(url, request_data)
@@ -578,7 +582,7 @@ class TransactionAdminCreateViewTests(APITestBase):
         assert response_data["content_key"] == request_data["content_key"]
         assert response_data["lms_user_id"] == request_data["lms_user_id"]
         assert response_data["subsidy_access_policy_uuid"] == request_data["subsidy_access_policy_uuid"]
-        assert response_data["metadata"] == {}
+        assert response_data["metadata"] == {'foo': 'bar'}
         assert response_data["unit"] == self.subsidy_1.ledger.unit
         assert response_data["quantity"] == -1000
         assert response_data["fulfillment_identifier"] == 'my-fulfillment-id'

--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -9,7 +9,6 @@ Some defintions:
 * `redemption`: The act of redeeming stored value for content.
 """
 from datetime import datetime, timezone
-from functools import lru_cache
 from unittest import mock
 from uuid import uuid4
 
@@ -207,7 +206,6 @@ class Subsidy(TimeStampedModel):
         """
         return GEAGFulfillmentHandler()
 
-    @lru_cache(maxsize=64)
     def price_for_content(self, content_key):
         """
         Return the price of the given content in USD Cents.

--- a/enterprise_subsidy/apps/subsidy/tests/test_models.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_models.py
@@ -44,11 +44,6 @@ class SubsidyModelReadTestCase(TestCase):
         cls.subsidy.content_metadata_api = mock.MagicMock()
         super().setUpTestData()
 
-    def setUp(self):
-        super().setUp()
-        # Clear the method cache between tests to help make tests deterministic.
-        self.subsidy.price_for_content.cache_clear()
-
     def test_price_for_content(self):
         """
         Tests that Subsidy.price_for_content returns the price of a piece


### PR DESCRIPTION
### Description
Threads `metadata` through to the `redeem()` call, so that we can support e.g. GEAG fulfillment.

also removes use of lru_cache from Subsidy.price_for_content() method, because
    we're unsure how it actually "works"

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
