### PR TITLE
fix: pass email and data consent to geag

### DIFF
--- a/enterprise_subsidy/apps/fulfillment/api.py
+++ b/enterprise_subsidy/apps/fulfillment/api.py
@@ -56,8 +56,10 @@ class GEAGFulfillmentHandler():
     REQUIRED_METADATA_FIELDS = [
         'geag_first_name',
         'geag_last_name',
+        'geag_email',
         'geag_date_of_birth',
-        'geag_terms_accepted_at'
+        'geag_terms_accepted_at',
+        'geag_data_share_consent',
     ]
 
     def get_smarter_client(self):
@@ -96,8 +98,10 @@ class GEAGFulfillmentHandler():
             ],
             'first_name': transaction.metadata.get('geag_first_name'),
             'last_name': transaction.metadata.get('geag_last_name'),
+            'email': transaction.metadata.get('geag_email'),
             'date_of_birth': transaction.metadata.get('geag_date_of_birth'),
             'terms_accepted_at': transaction.metadata.get('geag_terms_accepted_at'),
+            'data_share_consent': transaction.metadata.get('geag_data_share_consent'),
         }
 
     def _validate(self, transaction):

--- a/enterprise_subsidy/apps/fulfillment/tests/test_api.py
+++ b/enterprise_subsidy/apps/fulfillment/tests/test_api.py
@@ -114,8 +114,10 @@ class GEAGFulfillmentHandlerTestCase(TestCase):
         tx_metadata = {
             'geag_first_name': 'Donny',
             'geag_last_name': 'Kerabatsos',
+            'geag_email': 'donny@example.com',
             'geag_date_of_birth': '1900-01-01',
             'geag_terms_accepted_at': '2021-05-21T17:32:28Z',
+            'geag_data_share_consent': True,
         }
         transaction = TransactionFactory.create(
             state=TransactionStateChoices.PENDING,
@@ -140,8 +142,10 @@ class GEAGFulfillmentHandlerTestCase(TestCase):
         tx_metadata = {
             'geag_first_name': 'Donny',
             'geag_last_name': 'Kerabatsos',
+            'geag_email': 'donny@example.com',
             'geag_date_of_birth': '1900-01-01',
             'geag_terms_accepted_at': '2021-05-21T17:32:28Z',
+            'geag_data_share_consent': True,
         }
         transaction = TransactionFactory.create(
             state=TransactionStateChoices.PENDING,
@@ -161,8 +165,10 @@ class GEAGFulfillmentHandlerTestCase(TestCase):
         tx_metadata = {
             'geag_first_name': 'Donny',
             'geag_last_name': 'Kerabatsos',
+            'geag_email': 'donny@example.com',
             'geag_date_of_birth': '1900-01-01',
             'geag_terms_accepted_at': '2021-05-21T17:32:28Z',
+            'geag_data_share_consent': True,
         }
         transaction = TransactionFactory.create(
             state=TransactionStateChoices.PENDING,
@@ -201,8 +207,10 @@ class GEAGFulfillmentHandlerTestCase(TestCase):
         tx_metadata = {
             'geag_first_name': 'Donny',
             'geag_last_name': 'Kerabatsos',
+            'geag_email': 'donny@example.com',
             'geag_date_of_birth': '1900-01-01',
             'geag_terms_accepted_at': '2021-05-21T17:32:28Z',
+            'geag_data_share_consent': True,
         }
         transaction = TransactionFactory.create(
             state=TransactionStateChoices.PENDING,


### PR DESCRIPTION
### Description

- geag needs an email address and data share consent
- we'll have the frontend pass both (rather than look it up)

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
