### PR TITLE
feat: control content-metadata cache timeout from settings.

### DIFF
--- a/enterprise_subsidy/apps/api/v1/views/content_metadata.py
+++ b/enterprise_subsidy/apps/api/v1/views/content_metadata.py
@@ -4,6 +4,7 @@ Views for the enterprise-subsidy service relating to content metadata.
 import logging
 
 import requests
+from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from edx_rbac.mixins import PermissionRequiredMixin
@@ -27,6 +28,9 @@ from enterprise_subsidy.apps.subsidy.constants import (
 from enterprise_subsidy.apps.subsidy.models import EnterpriseSubsidyRoleAssignment
 
 logger = logging.getLogger(__name__)
+
+
+CONTENT_METADATA_VIEW_CACHE_TIMEOUT_SECONDS = getattr(settings, 'CONTENT_METADATA_VIEW_CACHE_TIMEOUT_SECONDS', 60)
 
 
 class ContentMetadataViewSet(
@@ -75,7 +79,7 @@ class ContentMetadataViewSet(
         """
         return utils.get_enterprise_uuid_from_request_query_params(self.request)
 
-    @method_decorator(cache_page(60))
+    @method_decorator(cache_page(CONTENT_METADATA_VIEW_CACHE_TIMEOUT_SECONDS))
     @method_decorator(require_at_least_one_query_parameter('enterprise_customer_uuid'))
     @action(detail=True)
     def get(self, request, content_identifier, enterprise_customer_uuid):

--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -340,3 +340,7 @@ LOGGING = get_logger_config(debug=DEBUG)
 
 # Application settings
 ALLOW_LEDGER_MODIFICATION = False
+
+# per-view cache timeout settings
+# We can disable caching on this view by setting the value below to 0.
+CONTENT_METADATA_VIEW_CACHE_TIMEOUT_SECONDS = 60


### PR DESCRIPTION
### Description
https://2u-internal.atlassian.net/browse/ENT-7135
We actually already have a per-view cache decorator on the content-metadata GET handler.

[Django](https://docs.djangoproject.com/en/3.2/topics/cache/#the-per-view-cache)   It’s currently set to cache for 60 seconds.  As the docs note: “Additionally, cache_page automatically sets Cache-Control and Expires headers in the response which affect [downstream caches](https://docs.djangoproject.com/en/3.2/topics/cache/#downstream-caches).”

This PR makes us accept a settings variable to control the timeout of the cache.  This will allow us to tune higher for performance, or to disable it as needed by setting the timeout to 0.

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
