### PR TITLE
feat: include auth_org_id in geag allocation

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -136,7 +136,7 @@ fastavro==1.7.4
     # via openedx-events
 future==0.18.3
     # via pyjwkest
-getsmarter-api-clients==0.5.3
+getsmarter-api-clients==0.5.4
     # via -r requirements/base.in
 idna==3.4
     # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -239,7 +239,7 @@ future==0.18.3
     # via
     #   -r requirements/validation.txt
     #   pyjwkest
-getsmarter-api-clients==0.5.3
+getsmarter-api-clients==0.5.4
     # via -r requirements/validation.txt
 idna==3.4
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -236,7 +236,7 @@ future==0.18.3
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-getsmarter-api-clients==0.5.3
+getsmarter-api-clients==0.5.4
     # via -r requirements/test.txt
 idna==3.4
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -161,7 +161,7 @@ future==0.18.3
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-getsmarter-api-clients==0.5.3
+getsmarter-api-clients==0.5.4
     # via -r requirements/base.txt
 gevent==22.10.2
     # via -r requirements/production.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -219,7 +219,7 @@ future==0.18.3
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-getsmarter-api-clients==0.5.3
+getsmarter-api-clients==0.5.4
     # via -r requirements/test.txt
 idna==3.4
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -199,7 +199,7 @@ future==0.18.3
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-getsmarter-api-clients==0.5.3
+getsmarter-api-clients==0.5.4
     # via -r requirements/base.txt
 idna==3.4
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -275,7 +275,7 @@ future==0.18.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pyjwkest
-getsmarter-api-clients==0.5.3
+getsmarter-api-clients==0.5.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description

- grab enterprise customer data, extract `auth_org_id`
- pipe `auth_org_id` into geag enterprise allocation call
- profit
- https://2u-internal.atlassian.net/browse/ENT-7079

