### PR TITLE
feat: adds support tools localhost to devstack cors whitelist

### DIFF
--- a/enterprise_subsidy/settings/devstack.py
+++ b/enterprise_subsidy/settings/devstack.py
@@ -1,5 +1,9 @@
 from enterprise_subsidy.settings.local import *
 
+CORS_ORIGIN_WHITELIST = (
+    'http://localhost:18450',  # frontend-app-support-tools
+)
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',


### PR DESCRIPTION
### Description
Describe in a couple of sentences what this PR adds

Adds the localhost port for frontend-app-support-tools to the devstack `CORS_ORIGIN_WHITELIST`.

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
