### PR TITLE
fix: use product source slug

### DIFF
--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -70,7 +70,7 @@ class ContentMetadataApi:
         Helps get the product source string, given a dict of ``content_data``.
         """
         if product_source := content_data.get('product_source'):
-            source_name = product_source.get('name')
+            source_name = product_source.get('slug')
             if source_name in CONTENT_MODES_BY_PRODUCT_SOURCE:
                 return source_name
         return ProductSources.EDX.value

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 CONTENT_MODES_BY_PRODUCT_SOURCE = {
     ProductSources.EDX.value: CourseModes.EDX_VERIFIED.value,
+    # TODO: additionally support other course modes/types beyond Executive Education for the 2U product source
     ProductSources.TWOU.value: CourseModes.EXECUTIVE_EDUCATION.value,
 }
 

--- a/enterprise_subsidy/apps/content_metadata/tests/test_api.py
+++ b/enterprise_subsidy/apps/content_metadata/tests/test_api.py
@@ -211,7 +211,7 @@ class ContentMetadataApiTests(TestCase):
         },
         {
             'content_data': {
-                'product_source': {'name': ProductSources.EDX.value},
+                'product_source': {'name': ProductSources.EDX.value, 'slug': ProductSources.EDX.value},
                 'entitlements': [{'mode': CourseModes.EDX_VERIFIED.value, 'price': '3.50'}],
             },
             'course_run_data': {},
@@ -219,7 +219,7 @@ class ContentMetadataApiTests(TestCase):
         },
         {
             'content_data': {
-                'product_source': {'name': ProductSources.TWOU.value},
+                'product_source': {'name': ProductSources.TWOU.value, 'slug': ProductSources.TWOU.value},
                 'entitlements': [{'mode': CourseModes.EXECUTIVE_EDUCATION.value, 'price': '4.20'}],
             },
             'course_run_data': {},


### PR DESCRIPTION
### Description

Uses `product_source`'s `slug` instead of `name`, as the `name` field should be assumed to be changed at any time, although name and slug are currently identical on stage/prod.

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
