### PR TITLE
fix: get_course_run() should early return if the content data is a course run

### DIFF
--- a/enterprise_subsidy/apps/api/v1/views/content_metadata.py
+++ b/enterprise_subsidy/apps/api/v1/views/content_metadata.py
@@ -109,7 +109,7 @@ class ContentMetadataViewSet(
                 content_identifier
             )
             if not content_summary.get('content_price'):
-                logger.warning("Could not find course price in metadata for {content_identifier}")
+                logger.warning(f"Could not find course price in metadata for {content_identifier}")
         except requests.exceptions.HTTPError as exc:
             if exc.response.status_code == 404:
                 return Response("Content not found", HTTP_404_NOT_FOUND)

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -109,6 +109,9 @@ class ContentMetadataApi:
         When given a run key or uuid for a run, extract that. When given a course key or
         course uuid, extract the advertised course_run.
         """
+        if content_data.get('content_type') == 'courserun':
+            return content_data
+
         course_run_identifier = content_identifier
         # if the supplied content_identifer refers to the course, look for an advertised run
         if content_identifier == content_data.get('key') or content_identifier == content_data.get('uuid'):


### PR DESCRIPTION
### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
