### PR TITLE
feat: allow transaction view to be filtered by state. ENT-7178

### DIFF
--- a/docs/decisions/0006-transaction-api-state-filtering.rst
+++ b/docs/decisions/0006-transaction-api-state-filtering.rst
@@ -1,0 +1,38 @@
+0006 Transaction API State Filtering
+####################################
+
+Status
+******
+
+**Accepted**
+May 2023
+
+Context
+*******
+
+The Transactions list endpoint is used by clients to determine which
+transactions already exist that match some criteria, for example:
+
+- To find all transactions for a given ``(user, content pair)``.
+- To find all transactions pertaining to some Subsidy Access Policy.
+
+These types of queries often need to be filtered by the state of the transaction -
+for example, an access policy typically wants to consider only ``pending`` or ``committed``
+transactions when considering if its set of existing transactions has a summed quantity
+less than some spending limit.
+
+Decision
+********
+
+We'll augment the V2 Admin Transaction list view to support filtering by multiple,
+"OR’d" values, e.g. ``state=committed&state=failed``
+should return transactions in either the committed or failed state.
+This view still defaults to returning otherwise-matching transactions
+in `any` state.
+
+Consequences
+************
+
+Clients will not be able to depend on the transactions API to "do the right thing"
+for them - they'll have to filter down to transaction states that are
+appropriate for their use cases.

--- a/enterprise_subsidy/apps/api/filters.py
+++ b/enterprise_subsidy/apps/api/filters.py
@@ -2,8 +2,9 @@
 Defines django-filter/DRF FilterSets
 for our API views.
 """
+from django_filters import filters
 from django_filters import rest_framework as drf_filters
-from openedx_ledger.models import Transaction
+from openedx_ledger.models import Transaction, TransactionStateChoices
 
 
 class HelpfulFilterSet(drf_filters.FilterSet):
@@ -27,7 +28,21 @@ class TransactionAdminFilterSet(HelpfulFilterSet):
     """
     Filters for admin transaction list action.
     """
+    # It's important that this is filtered as a `MultipleChoiceFilter`,
+    # which allows us to specify multiple matching state values
+    # in the request query params - this filter type performs an OR
+    # by default.
+    # https://django-filter.readthedocs.io/en/main/ref/filters.html?highlight=MultipleChoiceFilter#multiplechoicefilter
+    state = filters.MultipleChoiceFilter(
+        field_name='state',
+        choices=TransactionStateChoices.CHOICES,
+    )
 
     class Meta:
         model = Transaction
-        fields = ['lms_user_id', 'content_key', 'subsidy_access_policy_uuid']
+        fields = [
+            'lms_user_id',
+            'content_key',
+            'subsidy_access_policy_uuid',
+            'state',
+        ]

--- a/enterprise_subsidy/apps/fulfillment/api.py
+++ b/enterprise_subsidy/apps/fulfillment/api.py
@@ -150,7 +150,6 @@ class GEAGFulfillmentHandler():
         return bool(self._get_geag_variant_id(transaction))
 
     def _fulfill_in_geag(self, allocation_payload):
-        # pylint: disable=assignment-from-no-return
         geag_response = self.get_smarter_client().create_enterprise_allocation(**allocation_payload)
         return geag_response.json()
 


### PR DESCRIPTION
### Description
https://2u-internal.atlassian.net/browse/ENT-7178
With this change, the v2 transaction endpoint will:
* allow for filtering by multiple, OR’d values, e.g. `state=committed&state=failed` should return transactions in either the committed or failed state.
* default to returning otherwise-matching transactions in any state. (i.e. the current behavior)

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
