### PR TITLE
feat: add localhost for frontend-app-learner-portal-enterprise to ent…

### DIFF
--- a/enterprise_subsidy/settings/devstack.py
+++ b/enterprise_subsidy/settings/devstack.py
@@ -2,6 +2,7 @@ from enterprise_subsidy.settings.local import *
 
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:18450',  # frontend-app-support-tools
+    'http://localhost:8734',  # frontend-app-learner-portal-enterprise
 )
 
 DATABASES = {


### PR DESCRIPTION
Add localhost:8743 (frontend-app-learner-portal-enterprise) to enterprise-subsidy's CORS_ORIGIN_WHITELIST

### Description
Describe in a couple of sentences what this PR adds

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
