### PR TITLE
feat: upgrade edx-rest-api-client and openedx-ledger

### DIFF
--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -285,7 +285,6 @@ class Subsidy(TimeStampedModel):
             ledger_transaction.fulfillment_identifier = fulfillment_identifier
         if external_reference:
             ledger_transaction.external_reference.set([external_reference])
-        ledger_transaction.state = "committed"
         ledger_transaction.state = TransactionStateChoices.COMMITTED
         ledger_transaction.save()
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -130,7 +130,7 @@ edx-rbac==1.7.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via -r requirements/base.in
 fastavro==1.7.4
     # via openedx-events
@@ -171,7 +171,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-openedx-ledger==0.3.3
+openedx-ledger==0.4.0
     # via -r requirements/base.in
 packaging==23.1
     # via drf-yasg

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -214,7 +214,7 @@ edx-rbac==1.7.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via -r requirements/validation.txt
 exceptiongroup==1.1.1
     # via
@@ -339,7 +339,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-openedx-ledger==0.3.3
+openedx-ledger==0.4.0
     # via -r requirements/validation.txt
 packaging==23.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -211,7 +211,7 @@ edx-rbac==1.7.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via -r requirements/test.txt
 exceptiongroup==1.1.1
     # via
@@ -327,7 +327,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.3.3
+openedx-ledger==0.4.0
     # via -r requirements/test.txt
 packaging==23.1
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -151,7 +151,7 @@ edx-rbac==1.7.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via -r requirements/base.txt
 fastavro==1.7.4
     # via
@@ -217,7 +217,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.3.3
+openedx-ledger==0.4.0
     # via -r requirements/base.txt
 packaging==23.1
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -194,7 +194,7 @@ edx-rbac==1.7.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via -r requirements/test.txt
 exceptiongroup==1.1.1
     # via
@@ -307,7 +307,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.3.3
+openedx-ledger==0.4.0
     # via -r requirements/test.txt
 packaging==23.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -179,7 +179,7 @@ edx-rbac==1.7.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via -r requirements/base.txt
 exceptiongroup==1.1.1
     # via pytest
@@ -259,7 +259,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.3.3
+openedx-ledger==0.4.0
     # via -r requirements/base.txt
 packaging==23.1
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -241,7 +241,7 @@ edx-rbac==1.7.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -393,7 +393,7 @@ openedx-events==8.0.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.3.3
+openedx-ledger==0.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description
https://github.com/openedx/openedx-ledger/releases/tag/0.4.0 to get only non-failed transactions to count toward the subsidy balance calculation.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
