### PR TITLE
feat: use request cache to store content metadata results.

### DIFF
--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -5,7 +5,10 @@ during subsidy redemption and fulfillment.
 import logging
 from decimal import Decimal
 
+from edx_django_utils.cache import RequestCache
+
 from enterprise_subsidy.apps.api_client.enterprise_catalog import EnterpriseCatalogApiClient
+from enterprise_subsidy.apps.core.utils import versioned_cache_key
 from enterprise_subsidy.apps.subsidy.constants import CENTS_PER_DOLLAR
 
 from .constants import CourseModes, ProductSources
@@ -18,6 +21,22 @@ CONTENT_MODES_BY_PRODUCT_SOURCE = {
     # TODO: additionally support other course modes/types beyond Executive Education for the 2U product source
     ProductSources.TWOU.value: CourseModes.EXECUTIVE_EDUCATION.value,
 }
+
+CACHE_NAMESPACE = 'content_metadata'
+
+
+def content_metadata_cache_key(enterprise_customer_uuid, content_key):
+    """
+    Returns a versioned cache key that includes the customer uuid and content_key.
+    """
+    return versioned_cache_key(enterprise_customer_uuid, content_key)
+
+
+def request_cache():
+    """
+    Helper that returns a namespaced RequestCache instance.
+    """
+    return RequestCache(namespace=CACHE_NAMESPACE)
 
 
 class ContentMetadataApi:
@@ -125,7 +144,7 @@ class ContentMetadataApi:
         """
         Returns a summary dict some content metadata, makes the client call
         """
-        course_details = self.catalog_client().get_content_metadata_for_customer(
+        course_details = self.get_content_metadata(
             enterprise_customer_uuid,
             content_identifier
         )
@@ -149,7 +168,7 @@ class ContentMetadataApi:
             the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
             does not exist, or is not present in a catalog associated with the customer.
         """
-        course_details = self.catalog_client().get_content_metadata_for_customer(
+        course_details = self.get_content_metadata(
             enterprise_customer_uuid,
             content_identifier
         )
@@ -173,7 +192,7 @@ class ContentMetadataApi:
             the method will log and throw an HTTPError exception. A 404 exception will be thrown if the content
             does not exist, or is not present in a catalog associated with the customer.
         """
-        course_details = self.catalog_client().get_content_metadata_for_customer(
+        course_details = self.get_content_metadata(
             enterprise_customer_uuid,
             content_identifier
         )
@@ -184,3 +203,22 @@ class ContentMetadataApi:
         Returns the GetSmarter product variant id or None
         """
         return self.get_content_summary(enterprise_customer_uuid, content_identifier).get('geag_variant_id')
+
+    @staticmethod
+    def get_content_metadata(enterprise_customer_uuid, content_identifier):
+        """
+        Fetches details about the given content from the request cache; or it fetches from the enterprise-catalog
+        API if not present in the request cache, and then request-caches that result.
+        """
+        cache_key = content_metadata_cache_key(enterprise_customer_uuid, content_identifier)
+        cached_response = request_cache().get_cached_response(cache_key)
+        if cached_response.is_found:
+            return cached_response.value
+
+        course_details = EnterpriseCatalogApiClient().get_content_metadata_for_customer(
+            enterprise_customer_uuid,
+            content_identifier
+        )
+        if course_details:
+            request_cache().set(cache_key, course_details)
+        return course_details

--- a/enterprise_subsidy/apps/core/tests/test_utils.py
+++ b/enterprise_subsidy/apps/core/tests/test_utils.py
@@ -1,0 +1,20 @@
+"""
+Test for utilities module.
+"""
+from django.test import TestCase
+
+from enterprise_subsidy import __version__ as code_version
+
+from ..utils import versioned_cache_key
+
+
+class TestUtils(TestCase):
+    """
+    Tests for the utilities module.
+    """
+    def test_versioned_cache_key(self):
+        with self.settings(CACHE_KEY_VERSION_STAMP='flapjacks'):
+            self.assertEqual(
+                versioned_cache_key('foo', 'bar'),
+                f'foo:bar:{code_version}:flapjacks',
+            )

--- a/enterprise_subsidy/apps/core/utils.py
+++ b/enterprise_subsidy/apps/core/utils.py
@@ -1,0 +1,21 @@
+"""
+Core utility function.
+"""
+from django.conf import settings
+
+from enterprise_subsidy import __version__ as code_version
+
+CACHE_KEY_SEP = ':'
+
+
+def versioned_cache_key(*args):
+    """
+    Utility to produce a versioned cache key, which includes
+    an optional settings variable and the current code version,
+    so that we can perform key-based cache invalidation.
+    """
+    components = [str(arg) for arg in args]
+    components.append(code_version)
+    if stamp_from_settings := getattr(settings, 'CACHE_KEY_VERSION_STAMP', None):
+        components.append(stamp_from_settings)
+    return CACHE_KEY_SEP.join(components)


### PR DESCRIPTION
### Description
Stores content metadata payload in the request cache, which should mean that we make at most one call per content key to enterprise-catalog from the enterprise-subsidy per `can_redeem` request.

### Testing instructions
* Run `make app-logs | grep enterprise-catalog` to tail the logs
* Make a request to `can_redeem`, either via enterprise-access, or directly against enterprise-subsidy
* Watch for only 1 request to enterprise-catalog
* Do this outside of this branch to notice that there are two such requests.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
