### PR TITLE
build: constraint edx-drf-extensions<8.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -118,8 +118,9 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.7.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-rbac
 edx-opaque-keys[django]==2.3.0
@@ -134,6 +135,8 @@ edx-rest-api-client==5.5.2
     # via -r requirements/base.in
 fastavro==1.7.4
     # via openedx-events
+future==0.18.3
+    # via pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/base.in
 idna==3.4
@@ -185,6 +188,10 @@ psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
+pycryptodomex==3.17
+    # via pyjwkest
+pyjwkest==1.4.2
+    # via edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
@@ -221,6 +228,7 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   pyjwkest
     #   requests-oauthlib
     #   slumber
     #   social-auth-core
@@ -244,6 +252,7 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-rbac
+    #   pyjwkest
     #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,4 +11,6 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-
+# TODO: edx-drf-extensions 8.8.0 introduced some JWT unpleasantness
+# https://github.com/openedx/edx-drf-extensions/issues/346
+edx-drf-extensions<8.8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -197,7 +197,7 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.7.0
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
@@ -235,6 +235,10 @@ filelock==3.12.0
     #   -r requirements/validation.txt
     #   tox
     #   virtualenv
+future==0.18.3
+    # via
+    #   -r requirements/validation.txt
+    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/validation.txt
 idna==3.4
@@ -396,6 +400,10 @@ pycparser==2.21
     # via
     #   -r requirements/validation.txt
     #   cffi
+pycryptodomex==3.17
+    # via
+    #   -r requirements/validation.txt
+    #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/validation.txt
 pygments==2.15.1
@@ -404,6 +412,10 @@ pygments==2.15.1
     #   diff-cover
     #   readme-renderer
     #   rich
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/validation.txt
+    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/validation.txt
@@ -499,6 +511,7 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   slumber
@@ -551,6 +564,7 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
+    #   pyjwkest
     #   python-dateutil
     #   tox
 slumber==0.7.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -196,8 +196,9 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.7.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-rbac
 edx-lint==5.3.4
@@ -232,6 +233,10 @@ filelock==3.12.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
+future==0.18.3
+    # via
+    #   -r requirements/test.txt
+    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/test.txt
 idna==3.4
@@ -374,6 +379,10 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
+pycryptodomex==3.17
+    # via
+    #   -r requirements/test.txt
+    #   pyjwkest
 pydata-sphinx-theme==0.13.3
     # via sphinx-book-theme
 pygments==2.15.1
@@ -384,6 +393,10 @@ pygments==2.15.1
     #   readme-renderer
     #   rich
     #   sphinx
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/test.txt
@@ -475,6 +488,7 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   slumber
@@ -522,6 +536,7 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
+    #   pyjwkest
     #   python-dateutil
     #   tox
 slumber==0.7.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -138,7 +138,7 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.7.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
@@ -157,6 +157,10 @@ fastavro==1.7.4
     # via
     #   -r requirements/base.txt
     #   openedx-events
+future==0.18.3
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/base.txt
 gevent==22.10.2
@@ -243,6 +247,14 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
+pycryptodomex==3.17
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
@@ -297,6 +309,7 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   pyjwkest
     #   requests-oauthlib
     #   slumber
     #   social-auth-core
@@ -328,6 +341,7 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-rbac
+    #   pyjwkest
     #   python-dateutil
     #   python-memcached
 slumber==0.7.1

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -177,8 +177,9 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.7.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-rbac
 edx-lint==5.3.4
@@ -215,6 +216,10 @@ filelock==3.12.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
+future==0.18.3
+    # via
+    #   -r requirements/test.txt
+    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/test.txt
 idna==3.4
@@ -353,12 +358,20 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
+pycryptodomex==3.17
+    # via
+    #   -r requirements/test.txt
+    #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.15.1
     # via
     #   readme-renderer
     #   rich
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/test.txt
@@ -447,6 +460,7 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   slumber
@@ -491,6 +505,7 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
+    #   pyjwkest
     #   python-dateutil
     #   tox
 slumber==0.7.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -164,8 +164,9 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.7.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-rbac
 edx-lint==5.3.4
@@ -195,6 +196,10 @@ filelock==3.12.0
     # via
     #   tox
     #   virtualenv
+future==0.18.3
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/base.txt
 idna==3.4
@@ -297,6 +302,14 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
+pycryptodomex==3.17
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
@@ -374,6 +387,7 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   pyjwkest
     #   requests-oauthlib
     #   slumber
     #   social-auth-core
@@ -407,6 +421,7 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
+    #   pyjwkest
     #   python-dateutil
     #   tox
 slumber==0.7.1

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -221,7 +221,7 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -270,6 +270,11 @@ filelock==3.12.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
+future==0.18.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via
     #   -r requirements/quality.txt
@@ -452,6 +457,11 @@ pycparser==2.21
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cffi
+pycryptodomex==3.17
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
 pygments==2.15.1
@@ -459,6 +469,11 @@ pygments==2.15.1
     #   -r requirements/quality.txt
     #   readme-renderer
     #   rich
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/quality.txt
@@ -569,6 +584,7 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   slumber
@@ -627,6 +643,7 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
+    #   pyjwkest
     #   python-dateutil
     #   tox
 slumber==0.7.1


### PR DESCRIPTION
### Description
We started running into “Incorrect padding” JWT errors after upgrading to edx-drf-extensions 8.8.0.
This pins edx-drf-extensions<8.8, reintroducing pyjwkest

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
