### PR TITLE
Revert "build: constraint edx-drf-extensions<8.8"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -118,9 +118,8 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-rbac
 edx-opaque-keys[django]==2.3.0
@@ -135,8 +134,6 @@ edx-rest-api-client==5.5.2
     # via -r requirements/base.in
 fastavro==1.7.4
     # via openedx-events
-future==0.18.3
-    # via pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/base.in
 idna==3.4
@@ -188,10 +185,6 @@ psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via pyjwkest
-pyjwkest==1.4.2
-    # via edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
@@ -228,7 +221,6 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   slumber
     #   social-auth-core
@@ -252,7 +244,6 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-rbac
-    #   pyjwkest
     #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,6 +11,4 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-# TODO: edx-drf-extensions 8.8.0 introduced some JWT unpleasantness
-# https://github.com/openedx/edx-drf-extensions/issues/346
-edx-drf-extensions<8.8
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -197,7 +197,7 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
@@ -235,10 +235,6 @@ filelock==3.12.0
     #   -r requirements/validation.txt
     #   tox
     #   virtualenv
-future==0.18.3
-    # via
-    #   -r requirements/validation.txt
-    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/validation.txt
 idna==3.4
@@ -400,10 +396,6 @@ pycparser==2.21
     # via
     #   -r requirements/validation.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/validation.txt
-    #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/validation.txt
 pygments==2.15.1
@@ -412,10 +404,6 @@ pygments==2.15.1
     #   diff-cover
     #   readme-renderer
     #   rich
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/validation.txt
-    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/validation.txt
@@ -511,7 +499,6 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   slumber
@@ -564,7 +551,6 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
-    #   pyjwkest
     #   python-dateutil
     #   tox
 slumber==0.7.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -196,9 +196,8 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-rbac
 edx-lint==5.3.4
@@ -233,10 +232,6 @@ filelock==3.12.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-future==0.18.3
-    # via
-    #   -r requirements/test.txt
-    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/test.txt
 idna==3.4
@@ -379,10 +374,6 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/test.txt
-    #   pyjwkest
 pydata-sphinx-theme==0.13.3
     # via sphinx-book-theme
 pygments==2.15.1
@@ -393,10 +384,6 @@ pygments==2.15.1
     #   readme-renderer
     #   rich
     #   sphinx
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/test.txt
@@ -488,7 +475,6 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   slumber
@@ -536,7 +522,6 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
-    #   pyjwkest
     #   python-dateutil
     #   tox
 slumber==0.7.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -138,7 +138,7 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
@@ -157,10 +157,6 @@ fastavro==1.7.4
     # via
     #   -r requirements/base.txt
     #   openedx-events
-future==0.18.3
-    # via
-    #   -r requirements/base.txt
-    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/base.txt
 gevent==22.10.2
@@ -247,14 +243,6 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/base.txt
-    #   pyjwkest
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/base.txt
-    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
@@ -309,7 +297,6 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   slumber
     #   social-auth-core
@@ -341,7 +328,6 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-rbac
-    #   pyjwkest
     #   python-dateutil
     #   python-memcached
 slumber==0.7.1

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -177,9 +177,8 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-rbac
 edx-lint==5.3.4
@@ -216,10 +215,6 @@ filelock==3.12.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-future==0.18.3
-    # via
-    #   -r requirements/test.txt
-    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/test.txt
 idna==3.4
@@ -358,20 +353,12 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/test.txt
-    #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.15.1
     # via
     #   readme-renderer
     #   rich
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/test.txt
@@ -460,7 +447,6 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   slumber
@@ -505,7 +491,6 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
-    #   pyjwkest
     #   python-dateutil
     #   tox
 slumber==0.7.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -164,9 +164,8 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-rbac
 edx-lint==5.3.4
@@ -196,10 +195,6 @@ filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-future==0.18.3
-    # via
-    #   -r requirements/base.txt
-    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via -r requirements/base.txt
 idna==3.4
@@ -302,14 +297,6 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/base.txt
-    #   pyjwkest
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/base.txt
-    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
@@ -387,7 +374,6 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   slumber
     #   social-auth-core
@@ -421,7 +407,6 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
-    #   pyjwkest
     #   python-dateutil
     #   tox
 slumber==0.7.1

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -221,7 +221,7 @@ edx-django-utils==5.4.0
     #   edx-rest-api-client
     #   getsmarter-api-clients
     #   openedx-ledger
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -270,11 +270,6 @@ filelock==3.12.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-future==0.18.3
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   pyjwkest
 getsmarter-api-clients==0.5.4
     # via
     #   -r requirements/quality.txt
@@ -457,11 +452,6 @@ pycparser==2.21
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
 pygments==2.15.1
@@ -469,11 +459,6 @@ pygments==2.15.1
     #   -r requirements/quality.txt
     #   readme-renderer
     #   rich
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/quality.txt
@@ -584,7 +569,6 @@ requests==2.30.0
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   slumber
@@ -643,7 +627,6 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   edx-rbac
-    #   pyjwkest
     #   python-dateutil
     #   tox
 slumber==0.7.1


### PR DESCRIPTION
This reverts commit 02443266b921612b960ea22e1998c50ca7f7151e.

### Description
We've got a config change we think fixes the original issue.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
