### PR TITLE
feat: admin transaction create returns more structured error detail

### DIFF
--- a/enterprise_subsidy/__init__.py
+++ b/enterprise_subsidy/__init__.py
@@ -1,4 +1,4 @@
 """
 enterprise-subsidy module.
 """
-__version__ = '0.1.1'
+__version__ = '1.0.0'

--- a/enterprise_subsidy/apps/api/exceptions.py
+++ b/enterprise_subsidy/apps/api/exceptions.py
@@ -1,0 +1,38 @@
+"""
+Module to define API Exceptions that we return.
+"""
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class ErrorCodes:
+    """
+    Defines a few standard API error codes.
+    """
+    ENROLLMENT_ERROR = 'enrollment_error'
+    CONTENT_NOT_FOUND = 'content_not_found'
+    TRANSACTION_CREATION_ERROR = 'transaction_creation_error'
+    LEDGER_LOCK_ERROR = 'ledger_lock_error'
+
+
+class TransactionCreationAPIException(APIException):
+    """
+    Custom exception raised when transactions cannot be created.
+    """
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    default_detail = 'Error creating transaction.'
+    default_code = ErrorCodes.TRANSACTION_CREATION_ERROR
+
+    def __init__(self, detail=None, code=None, status_code=None):
+        """
+        This exception can override the default status_code
+        and also ensures that the error code makes its way
+        into the detail of the response.  `detail` will
+        always be returns as a dict.
+        """
+        super().__init__(detail=detail, code=code)
+        if status_code:
+            self.status_code = status_code
+        if not isinstance(self.detail, dict):
+            self.detail = {'detail': self.detail}
+        self.detail['code'] = code or self.default_code


### PR DESCRIPTION
Most error responses will now contain a JSON dict with 'detail' and 'code' keys, and result in a 422 response code when redemption could not occur. ENT-7132

https://2u-internal.atlassian.net/browse/ENT-7132

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
