### PR TITLE
chore: add transaction_status_api_url to transaction create response

### DIFF
--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -8,6 +8,7 @@ from functools import partial
 from unittest import mock
 
 import ddt
+from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned
 from edx_rbac.utils import ALL_ACCESS_CONTEXT
 from openedx_ledger.models import Transaction, TransactionStateChoices
@@ -132,6 +133,7 @@ class APITestBase(APITestMixin):
             str(self.subsidy_2_transaction_initial.uuid),
             str(self.subsidy_3_transaction_initial.uuid),
         ])
+        self.transaction_status_api_url = f"{settings.ENTERPRISE_SUBSIDY_URL}/api/v1/transactions"
 
 
 @ddt.ddt
@@ -235,6 +237,7 @@ class SubsidyViewSetTests(APITestBase):
                 'subsidy_access_policy_uuid': str(self.subsidy_access_policy_1_uuid),
                 'content_key': self.content_key_1,
                 'external_reference': [],
+                'transaction_status_api_url': f"{self.transaction_status_api_url}/{self.subsidy_1_transaction_1_uuid}/"
             }
 
         expected_response_data = {
@@ -923,6 +926,9 @@ class TransactionViewSetTests(APITestBase):
         assert len(create_response_data["uuid"]) == 36
         # TODO: make this assertion more specific once we hookup the idempotency_key to the request body.
         assert create_response_data["idempotency_key"]
+        assert create_response_data["transaction_status_api_url"] == (
+            f"{self.transaction_status_api_url}/{create_response_data['uuid']}/"
+        )
         assert create_response_data["content_key"] == post_data["content_key"]
         assert create_response_data["lms_user_id"] == post_data["lms_user_id"]
         assert create_response_data["subsidy_access_policy_uuid"] == post_data["subsidy_access_policy_uuid"]

--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -24,6 +24,7 @@ def root(*path_fragments):
 
 LMS_URL = os.environ.get('LMS_URL', 'localhost:18000')
 ENTERPRISE_CATALOG_URL = os.environ.get('ENTERPRISE_CATALOG_URL', 'localhost:18160')
+ENTERPRISE_SUBSIDY_URL = os.environ.get('ENTERPRISE_SUBSIDY_URL', 'localhost:18280')
 
 BULK_ENROLL_REQUEST_TIMEOUT_SECONDS = os.environ.get('BULK_ENROLL_REQUEST_TIMEOUT_SECONDS', 20)
 

--- a/enterprise_subsidy/settings/devstack.py
+++ b/enterprise_subsidy/settings/devstack.py
@@ -59,6 +59,7 @@ JWT_AUTH.update({
 
 LMS_URL = 'http://edx.devstack.lms:18000'
 ENTERPRISE_CATALOG_URL = 'http://enterprise.catalog.app:18160'
+ENTERPRISE_SUBSIDY_URL = 'http://localhost:18280'
 
 # Application settings
 ALLOW_LEDGER_MODIFICATION = True

--- a/enterprise_subsidy/settings/test.py
+++ b/enterprise_subsidy/settings/test.py
@@ -14,3 +14,5 @@ DATABASES = {
     },
 }
 # END IN-MEMORY TEST DATABASE
+
+ENTERPRISE_SUBSIDY_URL = 'http://enterprise-subsidy.app:18280'


### PR DESCRIPTION
### Description
This PR adds a `transaction_status_api_url` field to the transaction create response 

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
