### PR TITLE
fix: ensure new transactions to enroll in previously unenrolled courses flips the enrollment to active

### DIFF
--- a/enterprise_subsidy/apps/subsidy/api.py
+++ b/enterprise_subsidy/apps/subsidy/api.py
@@ -1,7 +1,6 @@
 """
 The python API.
 """
-from openedx_ledger.models import Transaction
 
 from enterprise_subsidy.apps.subsidy.models import RevenueCategoryChoices, Subsidy
 

--- a/enterprise_subsidy/apps/subsidy/api.py
+++ b/enterprise_subsidy/apps/subsidy/api.py
@@ -91,21 +91,10 @@ def can_redeem(subsidy, lms_user_id, content_key):
       )
     """
     existing_transaction = subsidy.get_redemption(lms_user_id, content_key)
-    if existing_transaction and not _existing_reversal(existing_transaction):
+    if existing_transaction:
         is_redeemable = False
         price_for_content = subsidy.price_for_content(content_key)
     else:
         is_redeemable, price_for_content = subsidy.is_redeemable(content_key)
 
     return (is_redeemable, price_for_content, existing_transaction)
-
-
-def _existing_reversal(transaction):
-    """
-    Helper that returns a ``Reversal`` record for a given transaction,
-    or None if no reversal exists.
-    """
-    try:
-        return transaction.reversal
-    except Transaction.reversal.RelatedObjectDoesNotExist:  # pylint: disable=no-member
-        return None

--- a/enterprise_subsidy/apps/subsidy/api.py
+++ b/enterprise_subsidy/apps/subsidy/api.py
@@ -90,7 +90,7 @@ def can_redeem(subsidy, lms_user_id, content_key):
         Transaction: existing redemption/transaction
       )
     """
-    existing_transaction = subsidy.get_redemption(lms_user_id, content_key)
+    existing_transaction = subsidy.get_committed_transaction_no_reversal(lms_user_id, content_key)
     if existing_transaction:
         is_redeemable = False
         price_for_content = subsidy.price_for_content(content_key)

--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -467,7 +467,7 @@ class Subsidy(TimeStampedModel):
 
     def get_redemption(self, lms_user_id, content_key):
         """
-        Return the committed transaction representing this redemption,
+        Return the committed transaction without a reversal representing this redemption,
         or None if no such transaction exists.
 
         Args:
@@ -479,6 +479,7 @@ class Subsidy(TimeStampedModel):
         """
         return self.transactions_for_learner_and_content(lms_user_id, content_key).filter(
             state=TransactionStateChoices.COMMITTED,
+            reversal__isnull=True,
         ).first()
 
     def all_transactions(self):

--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -316,7 +316,7 @@ class Subsidy(TimeStampedModel):
                 All other exceptions raised during the creation of an enrollment.  This should have already triggered
                 the rollback of a pending transaction.
         """
-        if existing_transaction := self.get_redemption(lms_user_id, content_key):
+        if existing_transaction := self.get_committed_transaction_no_reversal(lms_user_id, content_key):
             return (existing_transaction, False)
 
         is_redeemable, content_price = self.is_redeemable(content_key)
@@ -465,7 +465,7 @@ class Subsidy(TimeStampedModel):
             redeemable = self.current_balance() >= content_price
         return redeemable, content_price
 
-    def get_redemption(self, lms_user_id, content_key):
+    def get_committed_transaction_no_reversal(self, lms_user_id, content_key):
         """
         Return the committed transaction without a reversal representing this redemption,
         or None if no such transaction exists.

--- a/enterprise_subsidy/apps/subsidy/tests/test_api.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_api.py
@@ -103,11 +103,11 @@ class CanRedeemTestCase(TestCase):
             lms_user_id=self.lms_user_id,
             content_key=self.content_key
         )
-        reversal = Reversal.objects.create(
+        Reversal.objects.create(
             transaction=existing_transaction,
             idempotency_key=str(existing_transaction.idempotency_key) + '-reversed',
             quantity=19998,
-            state=TransactionStateChoices.COMMITTED,
+            state=TransactionStateChoices.CREATED,
         )
         expected_redeemable = True
         expected_price = 19998
@@ -117,8 +117,7 @@ class CanRedeemTestCase(TestCase):
         )
         self.assertEqual(expected_redeemable, actual_redeemable)
         self.assertEqual(expected_price, actual_price)
-        self.assertEqual(existing_transaction, actual_transaction)
-        self.assertEqual(actual_transaction.reversal, reversal)
+        self.assertEqual(None, actual_transaction)
 
     def test_existing_transaction_no_reversal(self):
         """

--- a/enterprise_subsidy/apps/subsidy/tests/test_api.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_api.py
@@ -107,7 +107,6 @@ class CanRedeemTestCase(TestCase):
             transaction=existing_transaction,
             idempotency_key=str(existing_transaction.idempotency_key) + '-reversed',
             quantity=19998,
-            state=TransactionStateChoices.CREATED,
         )
         expected_redeemable = True
         expected_price = 19998

--- a/enterprise_subsidy/apps/subsidy/tests/test_models.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_models.py
@@ -131,7 +131,7 @@ class SubsidyModelRedemptionTestCase(TestCase):
         )
         super().setUp()
 
-    def test_get_redemption(self):
+    def test_get_committed_transaction_no_reversal(self):
         """
         Tests that get_redemption appropriately filters by learner and content identifiers.
         """
@@ -150,7 +150,7 @@ class SubsidyModelRedemptionTestCase(TestCase):
             )
 
         for lms_user_id, content_key in learner_content_pairs:
-            transaction = self.subsidy.get_redemption(lms_user_id, content_key)
+            transaction = self.subsidy.get_committed_transaction_no_reversal(lms_user_id, content_key)
             self.assertEqual(transaction.lms_user_id, lms_user_id)
             self.assertEqual(transaction.content_key, content_key)
             self.assertEqual(transaction.quantity, -1000)


### PR DESCRIPTION
### Description

tl;dr; When redeeming a policy/subsidy for a course run that had been previously redeemed and then had the associated transaction and enrollment reversed, we don't allow the learner to redeem the course again but treat it as a success. The reason is that we see a committed transaction but don't take into the account the fact that it was reversed. So, we don't attempt redemption again when we should, so the learner's enrollment stays inactive.

#### Current state

1. Redeem a subsidy for some content by clicking the "Enroll" CTA on the course page and get redirected to courseware.
2. Return to course page and see "View course" button indicating existing enrollment.
3. Refund & unenroll the learner.
4. Observe that `CourseEnrollment.is_active=False` and the "Enroll" CTA returns on the course page.
5. Click the "Enroll" CTA and get redirected to courseware, with the expectation my previously unenrolled course is now active.
6. Return to course page and observe that `CourseEnrollment.is_active=False` still and the "Enroll" CTA is still shown, even though I had a successful POST `redeem` to enterprise-access.

#### Expected state

1. Redeem a subsidy for some content by clicking the "Enroll" CTA on the course page and get redirected to courseware.
2. Return to course page and see "View course" CTA indicating existing enrollment.
3. Refund & unenroll the learner.
4. Observe that `CourseEnrollment.is_active=False` and the "Enroll" CTA returns on the course page.
5. Click the "Enroll" CTA and get redirected to courseware, with the expectation my previously unenrolled course is now active.
6. Return to course page and and observe that `CourseEnrollment.is_active=True` now and the "View course" CTA is shown instead.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
