### PR TITLE
feat: memcached config for devstack, install pymemcache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
   memcache:
     image: memcached:1.4.24
     container_name: enterprise-subsidy.memcache
+    networks:
+      - devstack_default
+    command: memcached -vv
 
   app:
     image: openedx/enterprise-subsidy

--- a/enterprise_subsidy/settings/devstack.py
+++ b/enterprise_subsidy/settings/devstack.py
@@ -18,6 +18,14 @@ DATABASES = {
     }
 }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'LOCATION': 'enterprise-subsidy.memcache:11211',
+    }
+
+}
+
 # Generic OAuth2 variables irrespective of SSO/backend service key types.
 OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -22,6 +22,7 @@ jsonfield2
 mysqlclient
 openedx-events
 openedx-ledger
+pymemcache
 pytz
 rules
 getsmarter-api-clients

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -174,7 +174,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-openedx-ledger==0.4.0
+openedx-ledger==0.4.1
     # via -r requirements/base.in
 packaging==23.1
     # via drf-yasg
@@ -195,6 +195,8 @@ pyjwt[crypto]==2.7.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
+pymemcache==4.0.0
+    # via -r requirements/base.in
 pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
@@ -231,7 +233,7 @@ requests-oauthlib==1.3.1
     # via
     #   getsmarter-api-clients
     #   social-auth-core
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.27
     # via drf-yasg
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -262,7 +264,7 @@ stevedore==5.1.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via asgiref
 uritemplate==4.1.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -342,7 +342,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-openedx-ledger==0.4.0
+openedx-ledger==0.4.1
     # via -r requirements/validation.txt
 packaging==23.1
     # via
@@ -435,6 +435,8 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/validation.txt
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via -r requirements/validation.txt
 pymongo==3.13.0
     # via
     #   -r requirements/validation.txt
@@ -456,7 +458,7 @@ pytest==7.3.1
     #   -r requirements/validation.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/validation.txt
 pytest-django==4.5.2
     # via -r requirements/validation.txt
@@ -524,7 +526,7 @@ rich==13.3.5
     # via
     #   -r requirements/validation.txt
     #   twine
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.27
     # via
     #   -r requirements/validation.txt
     #   drf-yasg
@@ -606,7 +608,7 @@ tox==3.28.0
     # via -r requirements/validation.txt
 twine==4.0.2
     # via -r requirements/validation.txt
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/validation.txt
     #   asgiref

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -330,7 +330,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.4.0
+openedx-ledger==0.4.1
     # via -r requirements/test.txt
 packaging==23.1
     # via
@@ -415,6 +415,8 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via -r requirements/test.txt
 pymongo==3.13.0
     # via
     #   -r requirements/test.txt
@@ -434,7 +436,7 @@ pytest==7.3.1
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
@@ -497,7 +499,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.5
     # via twine
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.27
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -599,7 +601,7 @@ tox==3.28.0
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/doc.in
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/test.txt
     #   asgiref

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -220,7 +220,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.4.0
+openedx-ledger==0.4.1
     # via -r requirements/base.txt
 packaging==23.1
     # via
@@ -254,6 +254,8 @@ pyjwt[crypto]==2.7.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
+pymemcache==4.0.0
+    # via -r requirements/base.txt
 pymongo==3.13.0
     # via
     #   -r requirements/base.txt
@@ -308,7 +310,7 @@ requests-oauthlib==1.3.1
     #   -r requirements/base.txt
     #   getsmarter-api-clients
     #   social-auth-core
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.27
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -355,7 +357,7 @@ stevedore==5.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/base.txt
     #   asgiref

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -310,7 +310,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.4.0
+openedx-ledger==0.4.1
     # via -r requirements/test.txt
 packaging==23.1
     # via
@@ -390,6 +390,8 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via -r requirements/test.txt
 pymongo==3.13.0
     # via
     #   -r requirements/test.txt
@@ -407,7 +409,7 @@ pytest==7.3.1
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
@@ -466,7 +468,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.5
     # via twine
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.27
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -542,7 +544,7 @@ tox==3.28.0
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/quality.in
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/test.txt
     #   asgiref

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -262,7 +262,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==0.4.0
+openedx-ledger==0.4.1
     # via -r requirements/base.txt
 packaging==23.1
     # via
@@ -322,6 +322,8 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via -r requirements/base.txt
 pymongo==3.13.0
     # via
     #   -r requirements/base.txt
@@ -338,7 +340,7 @@ pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -385,7 +387,7 @@ requests-oauthlib==1.3.1
     #   -r requirements/base.txt
     #   getsmarter-api-clients
     #   social-auth-core
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.27
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -449,7 +451,7 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.in
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/base.txt
     #   asgiref

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -398,7 +398,7 @@ openedx-events==8.0.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==0.4.0
+openedx-ledger==0.4.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -497,6 +497,10 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 pymongo==3.13.0
     # via
     #   -r requirements/quality.txt
@@ -518,7 +522,7 @@ pytest==7.3.1
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -597,7 +601,7 @@ rich==13.3.5
     # via
     #   -r requirements/quality.txt
     #   twine
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.27
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -690,7 +694,7 @@ tox==3.28.0
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/quality.txt
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description
* Configure devstack settings to use memcached container
* install pymemcache package
* run memcache container on devstack default network

After this change/testing instructions:
```
./manage.py shell_plus
[...]
(InteractiveConsole)
>>> cache.get('go')
>>> cache.set('go', 2)
>>> cache.get('go')
2
>>> settings.CACHES
{'default': {'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache', 'LOCATION': 'enterprise-subsidy.memcache:11211'}}
```

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
