### PR TITLE
feat: send full transaction uuid to geag

### DIFF
--- a/enterprise_subsidy/apps/fulfillment/api.py
+++ b/enterprise_subsidy/apps/fulfillment/api.py
@@ -98,7 +98,7 @@ class GEAGFulfillmentHandler():
         # more fully understood.
         transaction_price = self._get_geag_transaction_price(transaction)
         return {
-            'payment_reference': str(transaction.uuid).replace('-', '')[:20],
+            'payment_reference': str(transaction.uuid),
             'enterprise_customer_uuid': str(self._get_enterprise_customer_uuid(transaction)),
             'currency': currency,
             'order_items': [

--- a/enterprise_subsidy/apps/fulfillment/tests/test_api.py
+++ b/enterprise_subsidy/apps/fulfillment/tests/test_api.py
@@ -134,7 +134,7 @@ class GEAGFulfillmentHandlerTestCase(TestCase):
         )
         # pylint: disable=protected-access
         geag_payload = self.geag_fulfillment_handler._create_allocation_payload(transaction)
-        assert geag_payload.get('payment_reference') == str(transaction.uuid).replace('-', '')[:20]
+        assert geag_payload.get('payment_reference') == str(transaction.uuid)
         assert geag_payload.get('order_items')[0].get('productId') == content_summary.get('geag_variant_id')
         assert geag_payload.get('org_id') == expected_enterprise_customer_data.get('auth_org_id')
         for payload_field in self.geag_fulfillment_handler.REQUIRED_METADATA_FIELDS:


### PR DESCRIPTION
### Description

- GEAG/Titan now supports 36 char payment reference ids
- We had been truncating our our reference id to 20 char previously
- https://2u-internal.atlassian.net/browse/ENT-7143

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
