### PR TITLE
feat: can_redeem - return full list of transactions

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -217,7 +217,9 @@ class TransactionCreationRequestSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         """
-        Creates a new Transaction record via the `Subsidy.redeem()` method.
+        Gets or creates a Transaction record via the `Subsidy.redeem()` method.
+
+        If an existing transaction is found with the same ledger and idempotency_key, that transaction is returned.
         """
         # subsidy() is a convenience property on the instance of the Transaction view class that uses
         # this serializer.
@@ -280,9 +282,15 @@ class CanRedeemResponseSerializer(serializers.Serializer):
         default='usd_cents',
         help_text='The unit in which price is denominated.'
     )
-    existing_transaction = TransactionSerializer(
+    all_transactions = TransactionSerializer(
         required=False,
         allow_null=True,
+        many=True,
+        help_text=(
+            'All existing transactions for the requested combination of (subsidy, access policy, lms_user_id, '
+            'content_key).  This includes active (committed without reversal), reversed, failed, pending, or created '
+            'transactions.'
+        ),
     )
 
 

--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -207,10 +207,10 @@ class SubsidyViewSetTests(APITestBase):
         self.set_up_admin(enterprise_uuids=[self.subsidy_1.enterprise_customer_uuid])
         expected_redeemable = True
         expected_price = 350
-        existing_transaction = None
+        existing_transactions = []
         if has_existing_transaction:
-            existing_transaction = self.subsidy_1_transaction_1
-        mock_can_redeem.return_value = (expected_redeemable, expected_price, existing_transaction)
+            existing_transactions.append(self.subsidy_1_transaction_1)
+        mock_can_redeem.return_value = (expected_redeemable, expected_price, existing_transactions)
         query_params = {'lms_user_id': 32, 'content_key': 'some-content-key'}
 
         response = self.client.get(
@@ -220,9 +220,9 @@ class SubsidyViewSetTests(APITestBase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        expected_existing_transaction = None
+        expected_existing_transactions = []
         if has_existing_transaction:
-            expected_existing_transaction = {
+            expected_existing_transactions.append({
                 'created': self.subsidy_1_transaction_1.created.strftime(SERIALIZED_DATE_PATTERN),
                 'idempotency_key': str(self.subsidy_1_transaction_1.idempotency_key),
                 'metadata': None,
@@ -239,13 +239,13 @@ class SubsidyViewSetTests(APITestBase):
                 'external_reference': [],
                 'transaction_status_api_url': f"{self.transaction_status_api_url}/{self.subsidy_1_transaction_1_uuid}/",
                 'courseware_url': f"http://localhost:2000/course/{self.content_key_1}/home",
-            }
+            })
 
         expected_response_data = {
             'can_redeem': expected_redeemable,
             'content_price': expected_price,
             'unit': self.subsidy_1.unit,
-            'existing_transaction': expected_existing_transaction,
+            'all_transactions': expected_existing_transactions,
         }
         self.assertEqual(response.json(), expected_response_data)
 

--- a/enterprise_subsidy/apps/api/v1/views/subsidy.py
+++ b/enterprise_subsidy/apps/api/v1/views/subsidy.py
@@ -42,12 +42,12 @@ class CanRedeemResult:
     DRF Serializers really prefer to operate on objects, not dictionaries,
     when they define a field that is itself a Serializer.
     """
-    def __init__(self, can_redeem, content_price, unit, existing_transaction):  # pylint: disable=redefined-outer-name
+    def __init__(self, can_redeem, content_price, unit, all_transactions):  # pylint: disable=redefined-outer-name
         """ initialize this object """
         self.can_redeem = can_redeem
         self.content_price = content_price
         self.unit = unit
-        self.existing_transaction = existing_transaction
+        self.all_transactions = all_transactions
 
 
 class SubsidyViewSet(
@@ -214,7 +214,7 @@ class SubsidyViewSet(
                 detail='A lms_user_id and content_key are required',
             )
 
-        redeemable, content_price, existing_transaction = can_redeem(
+        redeemable, content_price, existing_transactions = can_redeem(
             self.requested_subsidy,
             lms_user_id,
             content_key,
@@ -224,7 +224,7 @@ class SubsidyViewSet(
                 redeemable,
                 content_price,
                 self.requested_subsidy.unit,
-                existing_transaction,
+                existing_transactions,
             )
         )
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/enterprise_subsidy/apps/api/v2/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v2/views/transaction.py
@@ -142,8 +142,8 @@ class TransactionAdminListCreate(TransactionBaseViewMixin, generics.ListCreateAP
     def post(self, *args, **kwargs):
         """
         A create view that is accessible only to operators of the system.
-        It creates (or just gets, if a matching Transaction already exists) a transaction
-        via the `Subsidy.redeem()` method.
+        It creates (or just gets, if a matching Transaction is found with same ledger and idempotency_key) a
+        transaction via the `Subsidy.redeem()` method.
         """
         return super().post(*args, **kwargs)
 

--- a/enterprise_subsidy/apps/subsidy/api.py
+++ b/enterprise_subsidy/apps/subsidy/api.py
@@ -84,9 +84,9 @@ def can_redeem(subsidy, lms_user_id, content_key):
 
     Returns:
       3-tuple of (
-        boolean: whether the user can redeem,
-        int: price of content,
-        Transaction: existing redemption/transaction
+        boolean: whether the user can redeem.
+        int: price of content.
+        list of Transaction: all current and historical redemptions/transactions for user+content.
       )
     """
     existing_transaction = subsidy.get_committed_transaction_no_reversal(lms_user_id, content_key)
@@ -95,5 +95,7 @@ def can_redeem(subsidy, lms_user_id, content_key):
         price_for_content = subsidy.price_for_content(content_key)
     else:
         is_redeemable, price_for_content = subsidy.is_redeemable(content_key)
-
-    return (is_redeemable, price_for_content, existing_transaction)
+    all_transactions_for_learner_and_content = list(
+        subsidy.transactions_for_learner_and_content(lms_user_id, content_key)
+    )
+    return (is_redeemable, price_for_content, all_transactions_for_learner_and_content)

--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -470,6 +470,10 @@ class Subsidy(TimeStampedModel):
         Return the committed transaction without a reversal representing this redemption,
         or None if no such transaction exists.
 
+        TODO: Also include transactions with non-committed reversals (reversal.state != "committed").  Right now, this
+        defect has no real-world impact because we don't currently allow reversals to enter any non-committed state, but
+        this defect is probably worth fixing if reversals can become non-committed.
+
         Args:
             lms_user_id (str): The learner of the redemption to check.
             content_key (str): The content of the redemption to check.
@@ -494,6 +498,10 @@ class Subsidy(TimeStampedModel):
         return self.all_transactions().filter(content_key=content_key)
 
     def transactions_for_learner_and_content(self, lms_user_id, content_key):
+        """
+        Return all current and/or historical transactions representing the given user redeeming content.  Output may
+        contain reversed transactions.
+        """
         return self.all_transactions().filter(
             lms_user_id=lms_user_id,
             content_key=content_key,

--- a/enterprise_subsidy/apps/subsidy/tests/test_api.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_api.py
@@ -84,12 +84,12 @@ class CanRedeemTestCase(TestCase):
         expected_redeemable = True
         expected_price = 19998
 
-        actual_redeemable, actual_price, actual_transaction = subsidy_api.can_redeem(
+        actual_redeemable, actual_price, actual_transactions = subsidy_api.can_redeem(
             self.subsidy, self.lms_user_id, self.content_key
         )
         self.assertEqual(expected_redeemable, actual_redeemable)
         self.assertEqual(expected_price, actual_price)
-        self.assertIsNone(actual_transaction)
+        self.assertEqual([], actual_transactions)
 
     def test_existing_transaction_with_reversal(self):
         """
@@ -111,12 +111,12 @@ class CanRedeemTestCase(TestCase):
         expected_redeemable = True
         expected_price = 19998
 
-        actual_redeemable, actual_price, actual_transaction = subsidy_api.can_redeem(
+        actual_redeemable, actual_price, actual_transactions = subsidy_api.can_redeem(
             self.subsidy, self.lms_user_id, self.content_key
         )
         self.assertEqual(expected_redeemable, actual_redeemable)
         self.assertEqual(expected_price, actual_price)
-        self.assertEqual(None, actual_transaction)
+        self.assertEqual([existing_transaction], actual_transactions)
 
     def test_existing_transaction_no_reversal(self):
         """
@@ -133,9 +133,9 @@ class CanRedeemTestCase(TestCase):
         expected_redeemable = False
         expected_price = 19998
 
-        actual_redeemable, actual_price, actual_transaction = subsidy_api.can_redeem(
+        actual_redeemable, actual_price, actual_transactions = subsidy_api.can_redeem(
             self.subsidy, self.lms_user_id, self.content_key
         )
         self.assertEqual(expected_redeemable, actual_redeemable)
         self.assertEqual(expected_price, actual_price)
-        self.assertEqual(existing_transaction, actual_transaction)
+        self.assertEqual([existing_transaction], actual_transactions)


### PR DESCRIPTION
By returning a full list of transactions, enterprise-access can generate a versioned idempotency key which takes historical redemptions into account, allowing the learner to re-redeem the same content even after unenrolling+revoking.

ENT-7204

All related PRs:
* https://github.com/openedx/enterprise-access/pull/191
* https://github.com/openedx/enterprise-subsidy/pull/113
* https://github.com/openedx/edx-enterprise-subsidy-client/pull/23