### PR TITLE
build: new devstack-specific tagged image with dev requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,3 +77,14 @@ CMD gunicorn --workers=2 --name enterprise-subsidy -c /edx/app/enterprise-subsid
 # This line is after the requirements so that changes to the code will not
 # bust the image cache
 COPY . /edx/app/enterprise-subsidy
+
+FROM app as newrelic
+RUN pip install newrelic
+CMD gunicorn --workers=2 --name enterprise-subsidy -c /edx/app/enterprise-subsidy/enterprise_subsidy/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_subsidy.wsgi:application
+
+FROM app as devstack
+USER root
+COPY requirements/dev.txt /edx/app/enterprise-subsidy/requirements/dev.txt
+RUN pip install -r requirements/dev.txt
+USER app
+CMD gunicorn --workers=2 --name enterprise-subsidy -c /edx/app/enterprise-subsidy/enterprise_subsidy/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_subsidy.wsgi:application

--- a/Makefile
+++ b/Makefile
@@ -164,18 +164,13 @@ docker_build:
 # devstack-themed shortcuts
 dev.up: dev.up.redis
 	docker-compose up -d
-	docker exec -u 0 -it enterprise-subsidy.app pip-sync -q requirements/dev.txt requirements/private.* requirements/test.txt
 
 dev.up.build: dev.up.redis
 	docker-compose up -d --build
-	docker exec -u 0 -it enterprise-subsidy.app pip install -r requirements/pip-tools.txt
-	docker exec -u 0 -it enterprise-subsidy.app pip-sync -q requirements/dev.txt requirements/private.* requirements/test.txt
 
 dev.up.build-no-cache: dev.up.redis
 	docker-compose build --no-cache
 	docker-compose up -d
-	docker exec -u 0 -it enterprise-subsidy.app pip install -r requirements/pip-tools.txt
-	docker exec -u 0 -it enterprise-subsidy.app pip-sync -q requirements/dev.txt requirements/private.* requirements/test.txt
 
 dev.up.redis: # This has the nice side effect of starting the devstack_default network
 	docker-compose -f $(DEVSTACK_WORKSPACE)/devstack/docker-compose.yml up -d redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,9 @@ services:
     command: memcached -vv
 
   app:
-    image: openedx/enterprise-subsidy
+    # Uncomment this line to use the official enterprise-subsidy base image
+    # image: openedx/enterprise-subsidy
+    image: openedx/enterprise-subsidy:latest-devstack
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This helps avoid the `django-debug-toolbar` not installed errors we all face when re-building/re-starting our subsidy containers on devstack.  It creates a new image tag called `latest-devstack` and uses that image by default in `docker-compose.yml`.  Within this tag, we install the dev requirements, so that django-debug-toolbar can be installed during our devstack build, which means it's always there as soon as the container starts.
(I copied this solution from enterprise-access)

### Testing instructions
```
make dev.down
make dev.up.build-no-cache
make app-shell
# observe that the app works out of the box
```

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
