### PR TITLE
chore: add frontend-app-admin-portal to CORS allowlist

### DIFF
--- a/enterprise_subsidy/settings/devstack.py
+++ b/enterprise_subsidy/settings/devstack.py
@@ -3,6 +3,7 @@ from enterprise_subsidy.settings.local import *
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:18450',  # frontend-app-support-tools
     'http://localhost:8734',  # frontend-app-learner-portal-enterprise
+    'http://localhost:1991',  # frontend-app-admin-portal
 )
 
 DATABASES = {


### PR DESCRIPTION
Add `frontend-app-admin-portal` to the CORS allowlist in devstack.

### Description
Describe in a couple of sentences what this PR adds

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
