### PR TITLE
fix: disallow transaction creation for inactive subsidies

### DIFF
--- a/enterprise_subsidy/apps/api/exceptions.py
+++ b/enterprise_subsidy/apps/api/exceptions.py
@@ -13,6 +13,7 @@ class ErrorCodes:
     CONTENT_NOT_FOUND = 'content_not_found'
     TRANSACTION_CREATION_ERROR = 'transaction_creation_error'
     LEDGER_LOCK_ERROR = 'ledger_lock_error'
+    INACTIVE_SUBSIDY_CREATION_ERROR = 'inactive_subsidy_creation_error'
 
 
 class TransactionCreationAPIException(APIException):

--- a/enterprise_subsidy/apps/api/v2/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v2/views/transaction.py
@@ -152,6 +152,11 @@ class TransactionAdminListCreate(TransactionBaseViewMixin, generics.ListCreateAP
         """
         See docstring for post() above.
         """
+        if not self.subsidy.is_active:
+            raise TransactionCreationAPIException(
+                detail='Cannot create a transaction in an inactive subsidy',
+                code=ErrorCodes.INACTIVE_SUBSIDY_CREATION_ERROR,
+            )
         try:
             response = super().create(request, subsidy_uuid)
             if self.did_transaction_already_exist:

--- a/enterprise_subsidy/apps/core/utils.py
+++ b/enterprise_subsidy/apps/core/utils.py
@@ -1,7 +1,10 @@
 """
 Core utility function.
 """
+from datetime import datetime
+
 from django.conf import settings
+from pytz import UTC
 
 from enterprise_subsidy import __version__ as code_version
 
@@ -19,3 +22,9 @@ def versioned_cache_key(*args):
     if stamp_from_settings := getattr(settings, 'CACHE_KEY_VERSION_STAMP', None):
         components.append(stamp_from_settings)
     return CACHE_KEY_SEP.join(components)
+
+
+# pylint: disable=no-value-for-parameter
+def localized_utcnow():
+    """Helper function to return localized utcnow()."""
+    return UTC.localize(datetime.utcnow())  # pylint: disable=no-value-for-parameter

--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -28,6 +28,7 @@ from simple_history.models import HistoricalRecords
 
 from enterprise_subsidy.apps.api_client.enterprise import EnterpriseApiClient
 from enterprise_subsidy.apps.content_metadata.api import ContentMetadataApi
+from enterprise_subsidy.apps.core.utils import localized_utcnow
 from enterprise_subsidy.apps.fulfillment.api import GEAGFulfillmentHandler
 
 MOCK_CATALOG_CLIENT = mock.MagicMock()
@@ -196,6 +197,14 @@ class Subsidy(TimeStampedModel):
         help_text="The datetime when this Subsidy is considered expired.  If null, this Subsidy is considered active."
         )
     history = HistoricalRecords()
+
+    @property
+    def is_active(self):
+        """
+        Returns true if the localized current time is
+        between ``active_datetime`` and ``expiration_datetime``.
+        """
+        return self.active_datetime <= localized_utcnow() <= self.expiration_datetime
 
     @cached_property
     def enterprise_client(self):


### PR DESCRIPTION
### Description
Check that the subsidy is "current" before creating any transactions via the V2 transactions admin creation view.

### Testing instructions
* Make a request against `http://localhost:18280/api/v2/subsidies/[a subsidy uuid]/admin/transactions/` after having changed your subsidy's active or expiration time via django admin.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
