### PR TITLE
chore: add is_active field to subsidy API read view

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -21,6 +21,7 @@ class SubsidySerializer(serializers.ModelSerializer):
     Serializer for the `Subsidy` model.
     """
     current_balance = serializers.SerializerMethodField(help_text="The current (remaining) balance of this subsidy.")
+    is_active = serializers.BooleanField(read_only=True, help_text="Whether this subsidy is currently active.")
 
     class Meta:
         """
@@ -40,6 +41,7 @@ class SubsidySerializer(serializers.ModelSerializer):
             "starting_balance",
             "internal_only",
             "revenue_category",
+            "is_active",
             # In the MVP implementation, there are only learner_credit subsidies.  Uncomment after subscription
             # subsidies are introduced.
             # "subsidy_type",

--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -166,6 +166,7 @@ class SubsidyViewSetTests(APITestBase):
             "starting_balance": self.subsidy_1.starting_balance,
             "internal_only": False,
             "revenue_category": RevenueCategoryChoices.BULK_ENROLLMENT_PREPAY,
+            "is_active": True,
         }
         self.assertEqual(expected_result, response.json())
 
@@ -265,7 +266,6 @@ class SubsidyViewSetTests(APITestBase):
         url = self.get_list_url
         data = SubsidyFactory.to_default_fields_dict()
         response = self.client.post(url, data, format='json')
-
         self.assertEqual(response.status_code, status_code)
 
     def test_create_subsidy_when_request_body_is_incomplete(self):

--- a/enterprise_subsidy/apps/api/v1/views/subsidy.py
+++ b/enterprise_subsidy/apps/api/v1/views/subsidy.py
@@ -251,18 +251,18 @@ class SubsidyViewSet(
         create_serializer = SubsidyCreationRequestSerializer(data=request.data)
         if create_serializer.is_valid(raise_exception=True):
             try:
+                validated_data = create_serializer.validated_data
                 subsidy, created = get_or_create_learner_credit_subsidy(
-                    create_serializer.data['reference_id'],
-                    create_serializer.data['default_title'],
-                    create_serializer.data['default_enterprise_customer_uuid'],
-                    create_serializer.data['default_active_datetime'],
-                    create_serializer.data['default_expiration_datetime'],
-                    create_serializer.data['default_unit'],
-                    create_serializer.data['default_starting_balance'],
-                    create_serializer.data['default_revenue_category'],
-                    create_serializer.data['default_internal_only'],
+                    validated_data['reference_id'],
+                    validated_data['default_title'],
+                    validated_data['default_enterprise_customer_uuid'],
+                    validated_data['default_active_datetime'],
+                    validated_data['default_expiration_datetime'],
+                    validated_data['default_unit'],
+                    validated_data['default_starting_balance'],
+                    validated_data['default_revenue_category'],
+                    validated_data['default_internal_only'],
                 )
-
                 if created:
                     return Response(SubsidySerializer(subsidy).data, status=status.HTTP_201_CREATED)
                 if subsidy:


### PR DESCRIPTION
### Description
Add `is_active field` to  the `Subsidy` API read view

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
