### PR TITLE
feat: ContentMetadataApi.get_content_metadata uses TieredCache now

### DIFF
--- a/enterprise_subsidy/apps/core/utils.py
+++ b/enterprise_subsidy/apps/core/utils.py
@@ -24,7 +24,6 @@ def versioned_cache_key(*args):
     return CACHE_KEY_SEP.join(components)
 
 
-# pylint: disable=no-value-for-parameter
 def localized_utcnow():
     """Helper function to return localized utcnow()."""
     return UTC.localize(datetime.utcnow())  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Updates the ContentMetadataApi.get_content_metadata() method to use a TieredCache instead of a request cache. Uses a cache timeout that can be optionally overridden in settings, but defaults to 30 minutes if the setting is not present. 

https://2u-internal.atlassian.net/browse/ENT-7228

### Testing instructions

Hit the content-metadata API endpoint with two repeated calls with the same inputs, second should be faster.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
