### PR TITLE
feat: use djangoql in admin search

### DIFF
--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -209,13 +209,16 @@ class ContentMetadataApi:
         cache_key = content_metadata_cache_key(enterprise_customer_uuid, content_identifier)
         cached_response = TieredCache.get_cached_response(cache_key)
         if cached_response.is_found:
+            logger.info('[CONTENT METADATA CACHE HIT] for key %s', cache_key)
             return cached_response.value
 
+        logger.info('[CONTENT METADATA CACHE MISS] for key %s', cache_key)
         course_details = EnterpriseCatalogApiClient().get_content_metadata_for_customer(
             enterprise_customer_uuid,
             content_identifier
         )
         if course_details:
+            logger.info('[CONTENT METADATA CACHE SET] for key %s', cache_key)
             TieredCache.set_all_tiers(
                 cache_key,
                 course_details,

--- a/enterprise_subsidy/apps/subsidy/admin.py
+++ b/enterprise_subsidy/apps/subsidy/admin.py
@@ -5,6 +5,7 @@ import logging
 
 from django.conf import settings
 from django.contrib import admin
+from djangoql.admin import DjangoQLSearchMixin
 from edx_rbac.admin import UserRoleAssignmentAdmin
 from simple_history.admin import SimpleHistoryAdmin
 
@@ -29,7 +30,7 @@ def can_modify():
 
 
 @admin.register(Subsidy)
-class SubsidyAdmin(SimpleHistoryAdmin):
+class SubsidyAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
     """
     Admin for the Subsidy model.
     """
@@ -92,7 +93,7 @@ class SubsidyAdmin(SimpleHistoryAdmin):
 
 
 @admin.register(EnterpriseSubsidyRoleAssignment)
-class EnterpriseSubsidyRoleAssignmentAdmin(UserRoleAssignmentAdmin):
+class EnterpriseSubsidyRoleAssignmentAdmin(DjangoQLSearchMixin, UserRoleAssignmentAdmin):
     """
     Django admin for EnterpriseSubsidyRoleAssignment Model.
     """

--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -53,6 +53,7 @@ THIRD_PARTY_APPS = (
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens
     'django_filters',
     'django_object_actions',
+    'djangoql',
     'drf_spectacular',
     'drf_yasg',
     # "App Permissions" compatiblity: this provides the manage_user and manage_group management commands.


### PR DESCRIPTION
### Description
We've had djangoql installed in enterprise-subsidy for a while, but it's been unused.  I incorporated it into the Subsidy and Transaction models in a way that makes its use optional in a given search.

https://github.com/ivelum/djangoql#using-djangoql-with-the-standard-django-admin-search

### Testing instructions

Check out e.g. http://localhost:18280/admin/subsidy/subsidy/ after pulling this branch

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
