### PR TITLE
feat: hash the cache key to stay under max memcached length

### DIFF
--- a/enterprise_subsidy/apps/core/tests/test_utils.py
+++ b/enterprise_subsidy/apps/core/tests/test_utils.py
@@ -1,6 +1,8 @@
 """
 Test for utilities module.
 """
+import hashlib
+
 from django.test import TestCase
 
 from enterprise_subsidy import __version__ as code_version
@@ -16,5 +18,5 @@ class TestUtils(TestCase):
         with self.settings(CACHE_KEY_VERSION_STAMP='flapjacks'):
             self.assertEqual(
                 versioned_cache_key('foo', 'bar'),
-                f'foo:bar:{code_version}:flapjacks',
+                hashlib.sha512(f'foo:bar:{code_version}:flapjacks'.encode()).hexdigest(),
             )

--- a/enterprise_subsidy/apps/core/utils.py
+++ b/enterprise_subsidy/apps/core/utils.py
@@ -1,6 +1,7 @@
 """
 Core utility function.
 """
+import hashlib
 from datetime import datetime
 
 from django.conf import settings
@@ -21,7 +22,8 @@ def versioned_cache_key(*args):
     components.append(code_version)
     if stamp_from_settings := getattr(settings, 'CACHE_KEY_VERSION_STAMP', None):
         components.append(stamp_from_settings)
-    return CACHE_KEY_SEP.join(components)
+    decoded_cache_key = CACHE_KEY_SEP.join(components)
+    return hashlib.sha512(decoded_cache_key.encode()).hexdigest()
 
 
 def localized_utcnow():


### PR DESCRIPTION
### Description
Same idea as https://github.com/openedx/enterprise-access/pull/196

### Testing instructions
Hit can-redeem or redeem, you'll get a cache miss the first time, should get a cache hit the second time.  use `make app-logs | grep CACHE` to filter for the cache logging.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
