### PR TITLE
fix: Reversal.metadata field is not correctly serialized

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -62,6 +62,9 @@ class ReversalSerializer(serializers.ModelSerializer):
     """
     Serializer for the `Reversal` model.
     """
+    metadata = serializers.SerializerMethodField(
+        help_text="Any additional metadata that a client may want to associate with this Reversal instance."
+    )
 
     class Meta:
         """
@@ -77,6 +80,14 @@ class ReversalSerializer(serializers.ModelSerializer):
             "created",
             "modified",
         ]
+
+    @extend_schema_field(serializers.JSONField)
+    def get_metadata(self, obj) -> dict:
+        """
+        Properly serialize this json/dict
+        http://web.archive.org/web/20230427144910/https://romansorin.com/blog/using-djangos-jsonfield-you-probably-dont-need-it-heres-why
+        """
+        return obj.metadata
 
 
 class TransactionSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
* API before: the output-serialized reversal metadata key pointed to a string value containing JSON
* API after: the output-serialized reversal metadata key pointed to a nested JSON dictionary.

redoc before:
![image](https://github.com/openedx/enterprise-subsidy/assets/85151/948b0693-3f42-4b21-a23b-b4355be587c9)
redoc after:
![image](https://github.com/openedx/enterprise-subsidy/assets/85151/abcd11a9-9659-4157-a5da-dd7f2aae3110)
