### PR TITLE
feat: return fulfillment error payload in transaction creation response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,9 @@ tx
 
 # pyenv
 .python-version
+
+# doc spew
+docs/enterprise_subsidy.apps.*
+docs/enterprise_subsidy.rst
+docs/enterprise_subsidy.settings.rst
+docs/modules.rst

--- a/enterprise_subsidy/apps/api/exceptions.py
+++ b/enterprise_subsidy/apps/api/exceptions.py
@@ -14,6 +14,7 @@ class ErrorCodes:
     TRANSACTION_CREATION_ERROR = 'transaction_creation_error'
     LEDGER_LOCK_ERROR = 'ledger_lock_error'
     INACTIVE_SUBSIDY_CREATION_ERROR = 'inactive_subsidy_creation_error'
+    FULFILLMENT_ERROR = 'fulfillment_error'
 
 
 class TransactionCreationAPIException(APIException):

--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -11,6 +11,7 @@ from openedx_ledger.models import LedgerLockAttemptFailed, Reversal, Transaction
 from requests.exceptions import HTTPError
 from rest_framework import serializers
 
+from enterprise_subsidy.apps.fulfillment.api import FulfillmentException
 from enterprise_subsidy.apps.subsidy.models import ContentNotFoundForCustomerException, RevenueCategoryChoices, Subsidy
 
 logger = getLogger(__name__)
@@ -247,6 +248,11 @@ class TransactionCreationRequestSerializer(serializers.ModelSerializer):
             logger.exception(
                 f'Could not find content while creating transaction for {validated_data}'
                 f'in subsidy {subsidy.uuid}'
+            )
+            raise exc
+        except FulfillmentException as exc:
+            logger.error(
+                f'Error fulfilling transactions for {validated_data} in subsidy {subsidy.uuid}'
             )
             raise exc
         except Exception as exc:

--- a/enterprise_subsidy/apps/api/v2/tests/test_transaction_views.py
+++ b/enterprise_subsidy/apps/api/v2/tests/test_transaction_views.py
@@ -18,6 +18,7 @@ from enterprise_subsidy.apps.api.exceptions import ErrorCodes
 from enterprise_subsidy.apps.api.v1.serializers import TransactionCreationError
 from enterprise_subsidy.apps.api.v1.tests.mixins import STATIC_ENTERPRISE_UUID, STATIC_LMS_USER_ID, APITestMixin
 from enterprise_subsidy.apps.core.utils import localized_utcnow
+from enterprise_subsidy.apps.fulfillment.api import FulfillmentException
 from enterprise_subsidy.apps.subsidy.constants import SYSTEM_ENTERPRISE_ADMIN_ROLE, SYSTEM_ENTERPRISE_LEARNER_ROLE
 from enterprise_subsidy.apps.subsidy.models import ContentNotFoundForCustomerException
 from enterprise_subsidy.apps.subsidy.tests.factories import SubsidyFactory
@@ -551,6 +552,10 @@ class TransactionAdminCreateViewTests(APITestBase):
         {
             'exception_to_raise': Exception('Other error'),
             'expected_error_code': ErrorCodes.TRANSACTION_CREATION_ERROR,
+        },
+        {
+            'exception_to_raise': FulfillmentException('Fulfillment failure'),
+            'expected_error_code': ErrorCodes.FULFILLMENT_ERROR,
         },
     )
     @ddt.unpack

--- a/enterprise_subsidy/apps/api/v2/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v2/views/transaction.py
@@ -23,6 +23,7 @@ from enterprise_subsidy.apps.api.v1.serializers import (
     TransactionCreationRequestSerializer,
     TransactionSerializer
 )
+from enterprise_subsidy.apps.fulfillment.api import FulfillmentException
 from enterprise_subsidy.apps.subsidy.api import get_subsidy_by_uuid
 from enterprise_subsidy.apps.subsidy.constants import (
     PERMISSION_CAN_CREATE_TRANSACTIONS,
@@ -176,6 +177,11 @@ class TransactionAdminListCreate(TransactionBaseViewMixin, generics.ListCreateAP
             raise TransactionCreationAPIException(
                 detail=str(exc),
                 code=ErrorCodes.CONTENT_NOT_FOUND,
+            )
+        except FulfillmentException as exc:
+            raise TransactionCreationAPIException(
+                detail=str(exc),
+                code=ErrorCodes.FULFILLMENT_ERROR,
             )
         except TransactionCreationError as exc:
             raise TransactionCreationAPIException(detail=str(exc))

--- a/enterprise_subsidy/apps/fulfillment/tests/test_api.py
+++ b/enterprise_subsidy/apps/fulfillment/tests/test_api.py
@@ -1,18 +1,45 @@
 """
 Tests for functions defined in the ``api.py`` module.
 """
+from datetime import datetime
 from unittest import mock
 from uuid import uuid4
 
+import ddt
 import pytest
+import pytz
+import responses
+from django.conf import settings
 from django.test import TestCase
+from edx_django_utils.cache import TieredCache
 from openedx_ledger.models import TransactionStateChoices
 from openedx_ledger.test_utils.factories import TransactionFactory
+from rest_framework import status
 
-from enterprise_subsidy.apps.fulfillment.api import GEAGFulfillmentHandler, InvalidFulfillmentMetadataException
+from enterprise_subsidy.apps.fulfillment.api import (
+    FulfillmentException,
+    GEAGFulfillmentHandler,
+    InvalidFulfillmentMetadataException
+)
 from enterprise_subsidy.apps.subsidy.tests.factories import SubsidyFactory
 
 
+def mock_access_token(token='my-access-token'):
+    """
+    Helper to mock out the request the GEAG client uses
+    to fetch an access token.
+    """
+    TieredCache.set_all_tiers(
+        'get_smarter_api_client.access_token_response.{}'.format(settings.GET_SMARTER_OAUTH2_KEY),
+        {
+            'access_token': token,
+            'expires_in': 300,
+            'expires_at': datetime.now(pytz.utc).timestamp() + 300
+        },
+    )
+
+
+@ddt.ddt
 class GEAGFulfillmentHandlerTestCase(TestCase):
     """
     Test GEAGFulfillmentHandler
@@ -29,7 +56,34 @@ class GEAGFulfillmentHandlerTestCase(TestCase):
         self.subsidy.content_metadata_api().get_course_price.return_value = 19998
         self.lms_user_id = 42
         self.content_key = 'some-content-key'
+
+        self.mock_content_summary = {
+            'content_uuid': 'course-v1:edX-test-course',
+            'content_key': 'course-v1:edX-test-course',
+            'source': 'edX',
+            'mode': 'verified',
+            'content_price': 10000,
+            'geag_variant_id': str(uuid4()),
+        }
+        self.mock_tx_metadata = {
+            'geag_first_name': 'Donny',
+            'geag_last_name': 'Kerabatsos',
+            'geag_email': 'donny@example.com',
+            'geag_date_of_birth': '1900-01-01',
+            'geag_terms_accepted_at': '2021-05-21T17:32:28Z',
+            'geag_data_share_consent': True,
+        }
+        self.mock_transaction = TransactionFactory.create(
+            state=TransactionStateChoices.PENDING,
+            quantity=-19998,
+            ledger=self.subsidy.ledger,
+            lms_user_id=self.lms_user_id,
+            content_key=self.content_key,
+            metadata=self.mock_tx_metadata,
+        )
         super().setUp()
+
+        self.addCleanup(self.mock_transaction.delete)
 
     @mock.patch("enterprise_subsidy.apps.content_metadata.api.ContentMetadataApi.get_content_summary")
     def test_can_fulfill_ocm(self, mock_get_content_summary):
@@ -195,48 +249,78 @@ class GEAGFulfillmentHandlerTestCase(TestCase):
                 self.geag_fulfillment_handler._validate(transaction)
 
     @mock.patch("enterprise_subsidy.apps.content_metadata.api.ContentMetadataApi.get_content_summary")
-    @mock.patch("enterprise_subsidy.apps.fulfillment.api.GEAGFulfillmentHandler._fulfill_in_geag")
     @mock.patch("enterprise_subsidy.apps.api_client.enterprise.EnterpriseApiClient.get_enterprise_customer_data")
-    def test_fulfill(self, mock_get_enterprise_customer_data, mock_fulfill_in_geag, mock_get_content_summary):
+    @responses.activate
+    def test_fulfill(self, mock_get_enterprise_customer_data, mock_get_content_summary):
         """
         Ensure basic happy path of `fulfill`
         """
-        content_summary = {
-            'content_uuid': 'course-v1:edX-test-course',
-            'content_key': 'course-v1:edX-test-course',
-            'source': 'edX',
-            'mode': 'verified',
-            'content_price': 10000,
-            'geag_variant_id': str(uuid4()),
-        }
-        mock_get_content_summary.return_value = content_summary
-        expected_enterprise_customer_data = {
+        mock_get_content_summary.return_value = self.mock_content_summary
+        mock_get_enterprise_customer_data.return_value = {
             'auth_org_id': 'asde23eas',
         }
-        mock_get_enterprise_customer_data.return_value = expected_enterprise_customer_data
         geag_response = {
             'orderUuid': str(uuid4()),
         }
-        mock_fulfill_in_geag.return_value = geag_response
-        tx_metadata = {
-            'geag_first_name': 'Donny',
-            'geag_last_name': 'Kerabatsos',
-            'geag_email': 'donny@example.com',
-            'geag_date_of_birth': '1900-01-01',
-            'geag_terms_accepted_at': '2021-05-21T17:32:28Z',
-            'geag_data_share_consent': True,
-        }
-        transaction = TransactionFactory.create(
-            state=TransactionStateChoices.PENDING,
-            quantity=-19998,
-            ledger=self.subsidy.ledger,
-            lms_user_id=self.lms_user_id,
-            content_key=self.content_key,
-            metadata=tx_metadata,
+        mock_access_token()
+        responses.add(
+            responses.POST,
+            settings.GET_SMARTER_API_URL + '/enterprise_allocations',
+            json=geag_response,
+            status=status.HTTP_200_OK,
         )
-        external_transaction_reference = self.geag_fulfillment_handler.fulfill(transaction)
+
+        external_transaction_reference = self.geag_fulfillment_handler.fulfill(self.mock_transaction)
+
         assert external_transaction_reference
-        assert external_transaction_reference.transaction == transaction
+        assert external_transaction_reference.transaction == self.mock_transaction
         this_slug = external_transaction_reference.external_fulfillment_provider.slug
         assert this_slug == self.geag_fulfillment_handler.EXTERNAL_FULFILLMENT_PROVIDER_SLUG
         assert external_transaction_reference.external_reference_id == geag_response.get('orderUuid')
+
+    @mock.patch("enterprise_subsidy.apps.content_metadata.api.ContentMetadataApi.get_content_summary")
+    @mock.patch("enterprise_subsidy.apps.api_client.enterprise.EnterpriseApiClient.get_enterprise_customer_data")
+    @ddt.data(
+        {
+            'mock_geag_response_payload': {
+                'errors': [{'status': 'busted', 'reasons': 'I have my reasons'}],
+            },
+            'mock_geag_response_status': status.HTTP_400_BAD_REQUEST,
+            'expected_exception_regexp': 'I have my reasons',
+        },
+        {
+            'mock_geag_response_payload': {
+                'some': 'other identifier',
+            },
+            'mock_geag_response_status': status.HTTP_200_OK,
+            'expected_exception_regexp': 'missing orderUuid',
+        },
+    )
+    @ddt.unpack
+    @responses.activate
+    def test_fulfill_geag_client_error_conditions(
+        self,
+        mock_get_enterprise_customer_data,
+        mock_get_content_summary,
+        mock_geag_response_payload,
+        mock_geag_response_status,
+        expected_exception_regexp,
+    ):
+        """
+        Tests the handling of HTTPError responses and missing order UUIDs fromb
+        the get smarter API client.
+        """
+        mock_get_content_summary.return_value = self.mock_content_summary
+        mock_get_enterprise_customer_data.return_value = {
+            'auth_org_id': 'asde23eas',
+        }
+        mock_access_token()
+        responses.add(
+            responses.POST,
+            settings.GET_SMARTER_API_URL + '/enterprise_allocations',
+            json=mock_geag_response_payload,
+            status=mock_geag_response_status,
+        )
+
+        with self.assertRaisesRegex(FulfillmentException, expected_exception_regexp):
+            self.geag_fulfillment_handler.fulfill(self.mock_transaction)

--- a/enterprise_subsidy/settings/test.py
+++ b/enterprise_subsidy/settings/test.py
@@ -17,3 +17,8 @@ DATABASES = {
 
 ENTERPRISE_SUBSIDY_URL = 'http://enterprise-subsidy.app:18280'
 FRONTEND_APP_LEARNING_URL = 'http://localhost:2000'
+
+GET_SMARTER_API_URL = 'http://getsmarter.com/enterprise/allocate'
+GET_SMARTER_OAUTH2_KEY = 'get-smarter-key'
+GET_SMARTER_OAUTH2_SECRET = 'get-smarter-secret'
+GET_SMARTER_OAUTH2_PROVIDER_URL = 'https://get-smarter.provider.url'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -65,7 +65,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via
     #   -r requirements/base.in
     #   openedx-ledger
@@ -114,7 +114,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -137,7 +137,7 @@ edx-rest-api-client==5.5.2
     # via -r requirements/base.in
 fastavro==1.7.4
     # via openedx-events
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via -r requirements/base.in
 idna==3.4
     # via requests
@@ -157,7 +157,7 @@ jsonfield2==4.0.0.post0
     #   openedx-ledger
 jsonschema==4.17.3
     # via drf-spectacular
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mysqlclient==2.1.1
     # via
@@ -170,7 +170,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/base.in
     #   openedx-ledger
@@ -264,14 +264,14 @@ stevedore==5.1.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via asgiref
 uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
 zipp==3.15.0
     # via importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -135,7 +135,7 @@ django-debug-toolbar==4.1.0
     # via -r requirements/dev.in
 django-dynamic-fixture==3.1.2
     # via -r requirements/validation.txt
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via
     #   -r requirements/dev.in
     #   -r requirements/validation.txt
@@ -193,7 +193,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
@@ -225,7 +225,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==18.10.0
+faker==18.10.1
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -238,7 +238,7 @@ filelock==3.12.0
     #   -r requirements/validation.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via -r requirements/validation.txt
 idna==3.4
     # via
@@ -306,7 +306,7 @@ markdown-it-py==2.2.0
     # via
     #   -r requirements/validation.txt
     #   rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/validation.txt
     #   jinja2
@@ -338,7 +338,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
@@ -490,6 +490,7 @@ pyyaml==6.0
     #   drf-spectacular
     #   edx-django-release-util
     #   edx-i18n-tools
+    #   responses
 readme-renderer==37.3
     # via
     #   -r requirements/validation.txt
@@ -506,6 +507,7 @@ requests==2.31.0
     #   edx-rest-api-client
     #   requests-oauthlib
     #   requests-toolbelt
+    #   responses
     #   slumber
     #   social-auth-core
     #   twine
@@ -518,6 +520,8 @@ requests-toolbelt==1.0.0
     # via
     #   -r requirements/validation.txt
     #   twine
+responses==0.23.1
+    # via -r requirements/validation.txt
 rfc3986==2.0.0
     # via
     #   -r requirements/validation.txt
@@ -608,7 +612,11 @@ tox==3.28.0
     # via -r requirements/validation.txt
 twine==4.0.2
     # via -r requirements/validation.txt
-typing-extensions==4.6.2
+types-pyyaml==6.0.12.10
+    # via
+    #   -r requirements/validation.txt
+    #   responses
+typing-extensions==4.6.3
     # via
     #   -r requirements/validation.txt
     #   asgiref
@@ -621,10 +629,11 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/validation.txt
     #   requests
+    #   responses
     #   twine
 virtualenv==20.23.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -130,7 +130,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -192,7 +192,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -222,7 +222,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.10.0
+faker==18.10.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -235,7 +235,7 @@ filelock==3.12.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via -r requirements/test.txt
 idna==3.4
     # via
@@ -298,7 +298,7 @@ lazy-object-proxy==1.9.0
     #   astroid
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -326,7 +326,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -468,6 +468,7 @@ pyyaml==6.0
     #   code-annotations
     #   drf-spectacular
     #   edx-django-release-util
+    #   responses
 readme-renderer==37.3
     # via twine
 redis==4.5.5
@@ -482,6 +483,7 @@ requests==2.31.0
     #   edx-rest-api-client
     #   requests-oauthlib
     #   requests-toolbelt
+    #   responses
     #   slumber
     #   social-auth-core
     #   sphinx
@@ -493,6 +495,8 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 requests-toolbelt==1.0.0
     # via twine
+responses==0.23.1
+    # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
@@ -601,7 +605,11 @@ tox==3.28.0
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/doc.in
-typing-extensions==4.6.2
+types-pyyaml==6.0.12.10
+    # via
+    #   -r requirements/test.txt
+    #   responses
+typing-extensions==4.6.3
     # via
     #   -r requirements/test.txt
     #   asgiref
@@ -615,10 +623,11 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/test.txt
     #   requests
+    #   responses
     #   twine
 virtualenv==20.23.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -82,7 +82,7 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -134,7 +134,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -160,7 +160,7 @@ fastavro==1.7.4
     # via
     #   -r requirements/base.txt
     #   openedx-events
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via -r requirements/base.txt
 gevent==22.10.2
     # via -r requirements/production.in
@@ -197,7 +197,7 @@ jsonschema==4.17.3
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -216,7 +216,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -357,7 +357,7 @@ stevedore==5.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -r requirements/base.txt
     #   asgiref
@@ -367,7 +367,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -118,7 +118,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -173,7 +173,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -205,7 +205,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.10.0
+faker==18.10.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -218,7 +218,7 @@ filelock==3.12.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via -r requirements/test.txt
 idna==3.4
     # via
@@ -278,7 +278,7 @@ lazy-object-proxy==1.9.0
     #   astroid
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -306,7 +306,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -440,6 +440,7 @@ pyyaml==6.0
     #   code-annotations
     #   drf-spectacular
     #   edx-django-release-util
+    #   responses
 readme-renderer==37.3
     # via twine
 redis==4.5.5
@@ -454,6 +455,7 @@ requests==2.31.0
     #   edx-rest-api-client
     #   requests-oauthlib
     #   requests-toolbelt
+    #   responses
     #   slumber
     #   social-auth-core
     #   twine
@@ -464,6 +466,8 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 requests-toolbelt==1.0.0
     # via twine
+responses==0.23.1
+    # via -r requirements/test.txt
 rfc3986==2.0.0
     # via twine
 rich==13.4.1
@@ -544,7 +548,11 @@ tox==3.28.0
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/quality.in
-typing-extensions==4.6.2
+types-pyyaml==6.0.12.10
+    # via
+    #   -r requirements/test.txt
+    #   responses
+typing-extensions==4.6.3
     # via
     #   -r requirements/test.txt
     #   asgiref
@@ -557,10 +565,11 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/test.txt
     #   requests
+    #   responses
     #   twine
 virtualenv==20.23.0
     # via

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -12,4 +12,5 @@ factory-boy
 mock
 pytest-cov
 pytest-django
+responses
 tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -107,7 +107,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-dynamic-fixture==3.1.2
     # via -r requirements/test.in
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -160,7 +160,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -188,7 +188,7 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.10.0
+faker==18.10.1
     # via factory-boy
 fastavro==1.7.4
     # via
@@ -198,7 +198,7 @@ filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via -r requirements/base.txt
 idna==3.4
     # via
@@ -236,7 +236,7 @@ jsonschema==4.17.3
     #   drf-spectacular
 lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -258,7 +258,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -369,6 +369,7 @@ pyyaml==6.0
     #   code-annotations
     #   drf-spectacular
     #   edx-django-release-util
+    #   responses
 redis==4.5.5
     # via
     #   -r requirements/base.txt
@@ -380,6 +381,7 @@ requests==2.31.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
+    #   responses
     #   slumber
     #   social-auth-core
 requests-oauthlib==1.3.1
@@ -387,6 +389,8 @@ requests-oauthlib==1.3.1
     #   -r requirements/base.txt
     #   getsmarter-api-clients
     #   social-auth-core
+responses==0.23.1
+    # via -r requirements/test.in
 ruamel-yaml==0.17.31
     # via
     #   -r requirements/base.txt
@@ -451,7 +455,9 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.in
-typing-extensions==4.6.2
+types-pyyaml==6.0.12.10
+    # via responses
+typing-extensions==4.6.3
     # via
     #   -r requirements/base.txt
     #   asgiref
@@ -463,10 +469,11 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/base.txt
     #   requests
+    #   responses
 virtualenv==20.23.0
     # via tox
 wrapt==1.15.0

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -144,7 +144,7 @@ django-dynamic-fixture==3.1.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -218,7 +218,7 @@ edx-django-release-util==1.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -259,7 +259,7 @@ factory-boy==3.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==18.10.0
+faker==18.10.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -275,7 +275,7 @@ filelock==3.12.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -354,7 +354,7 @@ markdown-it-py==2.2.0
     # via
     #   -r requirements/quality.txt
     #   rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -393,7 +393,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -562,6 +562,7 @@ pyyaml==6.0
     #   code-annotations
     #   drf-spectacular
     #   edx-django-release-util
+    #   responses
 readme-renderer==37.3
     # via
     #   -r requirements/quality.txt
@@ -580,6 +581,7 @@ requests==2.31.0
     #   edx-rest-api-client
     #   requests-oauthlib
     #   requests-toolbelt
+    #   responses
     #   slumber
     #   social-auth-core
     #   twine
@@ -593,6 +595,10 @@ requests-toolbelt==1.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
+responses==0.23.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
@@ -694,7 +700,12 @@ tox==3.28.0
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/quality.txt
-typing-extensions==4.6.2
+types-pyyaml==6.0.12.10
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   responses
+typing-extensions==4.6.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -709,11 +720,12 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
+    #   responses
     #   twine
 virtualenv==20.23.0
     # via


### PR DESCRIPTION
Include fulfillment error messages in transaction creation error response payload.
https://2u-internal.atlassian.net/browse/ENT-7271
### Testing instructions
I'm relying on unit tests for local development, we can test in stage by trying to fulfill a GEAG course twice for the same user, before/after switching them to subsidy-based learner credit.  We could also test by trying to fulfill something with a mismatched variant id.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
