### PR TITLE
feat: clear cache option added to django admin

### DIFF
--- a/docs/how_to/clear_cache.rst
+++ b/docs/how_to/clear_cache.rst
@@ -1,0 +1,31 @@
+Manually clear Django cache 
+===========================
+
+At times, it is helpful to clear the cache for the application to enable more efficient QA in local/stage/production environments 
+when working with APIs that cache data from external sources. For instance, enterprise-subsidy makes an API request to enterprise-catalog to
+retrieve metadata about the enterprise catalog and caches it for 30 minutes.
+
+In order to get around this, `django-clearcache` (https://github.com/timonweb/django-clearcache) is installed and configured, which allows you to clear the cache for the application via
+Django and via a manage.py command.
+
+Via Django admin
+----------------
+
+1. Go to /admin/clearcache/, you should see a form with cache selector
+2. Pick a cache. Usually there's one default cache, but can be more.
+3. Click the button, you're done!
+
+Via manage.py command
+---------------------
+
+1. Run the following command to clear the default cache
+
+.. code-block:: bash
+
+    $ python manage.py clearcache
+
+2. Run the command above with an additional parameter to clear non-default cache (if exists):
+
+.. code-block:: bash
+
+    $ python manage.py clearcache cache_name

--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -40,6 +40,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = (
+    'clearcache',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/enterprise_subsidy/urls.py
+++ b/enterprise_subsidy/urls.py
@@ -54,6 +54,7 @@ spec_redoc_view = SpectacularRedocView(
 )
 
 urlpatterns = oauth2_urlpatterns + [
+    re_path(r'^admin/clearcache/', include('clearcache.urls')),
     re_path(r'^admin/', admin.site.urls),
     re_path(r'^api/', include(api_urls)),
     re_path(r'^api-docs(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -27,3 +27,4 @@ pytz
 rules
 getsmarter-api-clients
 django-log-request-id
+django-clearcache

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,6 +40,7 @@ django==3.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
+    #   django-clearcache
     #   django-cors-headers
     #   django-crum
     #   django-extensions
@@ -59,6 +60,8 @@ django==3.2.19
     #   openedx-events
     #   openedx-ledger
     #   social-auth-app-django
+django-clearcache==1.2.1
+    # via -r requirements/base.in
 django-cors-headers==4.0.0
     # via -r requirements/base.in
 django-crum==0.7.9

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,13 +6,13 @@
 #
 distlib==0.3.6
     # via virtualenv
-filelock==3.12.0
+filelock==3.12.1
     # via
     #   tox
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via virtualenv
 pluggy==1.0.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -90,7 +90,7 @@ defusedxml==0.7.1
     #   -r requirements/validation.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==7.5.0
+diff-cover==7.6.0
     # via -r requirements/dev.in
 dill==0.3.6
     # via
@@ -103,6 +103,7 @@ distlib==0.3.6
 django==3.2.19
     # via
     #   -r requirements/validation.txt
+    #   django-clearcache
     #   django-cors-headers
     #   django-crum
     #   django-debug-toolbar
@@ -124,6 +125,8 @@ django==3.2.19
     #   openedx-events
     #   openedx-ledger
     #   social-auth-app-django
+django-clearcache==1.2.1
+    # via -r requirements/validation.txt
 django-cors-headers==4.0.0
     # via -r requirements/validation.txt
 django-crum==0.7.9
@@ -233,7 +236,7 @@ fastavro==1.7.4
     # via
     #   -r requirements/validation.txt
     #   openedx-events
-filelock==3.12.0
+filelock==3.12.1
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -302,7 +305,7 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/validation.txt
     #   astroid
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via
     #   -r requirements/validation.txt
     #   rich
@@ -368,7 +371,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/validation.txt
     #   jsonschema
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -453,7 +456,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/validation.txt
     #   jsonschema
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
@@ -526,7 +529,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/validation.txt
     #   twine
-rich==13.4.1
+rich==13.4.2
     # via
     #   -r requirements/validation.txt
     #   twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -102,6 +102,7 @@ django==3.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
+    #   django-clearcache
     #   django-cors-headers
     #   django-crum
     #   django-extensions
@@ -121,6 +122,8 @@ django==3.2.19
     #   openedx-events
     #   openedx-ledger
     #   social-auth-app-django
+django-clearcache==1.2.1
+    # via -r requirements/test.txt
 django-cors-headers==4.0.0
     # via -r requirements/test.txt
 django-crum==0.7.9
@@ -230,7 +233,7 @@ fastavro==1.7.4
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.12.0
+filelock==3.12.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -296,7 +299,7 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/test.txt
     #   astroid
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.3
     # via
@@ -351,7 +354,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -431,7 +434,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/test.txt
     #   jsonschema
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -501,7 +504,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.4.1
+rich==13.4.2
     # via twine
 ruamel-yaml==0.17.31
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -56,6 +56,7 @@ defusedxml==0.7.1
 django==3.2.19
     # via
     #   -r requirements/base.txt
+    #   django-clearcache
     #   django-cors-headers
     #   django-crum
     #   django-extensions
@@ -75,6 +76,8 @@ django==3.2.19
     #   openedx-events
     #   openedx-ledger
     #   social-auth-app-django
+django-clearcache==1.2.1
+    # via -r requirements/base.txt
 django-cors-headers==4.0.0
     # via -r requirements/base.txt
 django-crum==0.7.9

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -90,6 +90,7 @@ django==3.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
+    #   django-clearcache
     #   django-cors-headers
     #   django-crum
     #   django-extensions
@@ -109,6 +110,8 @@ django==3.2.19
     #   openedx-events
     #   openedx-ledger
     #   social-auth-app-django
+django-clearcache==1.2.1
+    # via -r requirements/test.txt
 django-cors-headers==4.0.0
     # via -r requirements/test.txt
 django-crum==0.7.9
@@ -213,7 +216,7 @@ fastavro==1.7.4
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.12.0
+filelock==3.12.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -276,7 +279,7 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/test.txt
     #   astroid
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.3
     # via
@@ -328,7 +331,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -404,7 +407,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/test.txt
     #   jsonschema
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -470,7 +473,7 @@ responses==0.23.1
     # via -r requirements/test.txt
 rfc3986==2.0.0
     # via twine
-rich==13.4.1
+rich==13.4.2
     # via twine
 ruamel-yaml==0.17.31
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -79,6 +79,7 @@ distlib==0.3.6
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
+    #   django-clearcache
     #   django-cors-headers
     #   django-crum
     #   django-extensions
@@ -98,6 +99,8 @@ distlib==0.3.6
     #   openedx-events
     #   openedx-ledger
     #   social-auth-app-django
+django-clearcache==1.2.1
+    # via -r requirements/base.txt
 django-cors-headers==4.0.0
     # via -r requirements/base.txt
 django-crum==0.7.9
@@ -194,7 +197,7 @@ fastavro==1.7.4
     # via
     #   -r requirements/base.txt
     #   openedx-events
-filelock==3.12.0
+filelock==3.12.1
     # via
     #   tox
     #   virtualenv
@@ -278,7 +281,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/base.txt
     #   jsonschema
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   pylint
     #   virtualenv
@@ -336,7 +339,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/base.txt
     #   jsonschema
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   pytest-cov
     #   pytest-django

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -111,6 +111,7 @@ django==3.2.19
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   django-clearcache
     #   django-cors-headers
     #   django-crum
     #   django-extensions
@@ -130,6 +131,10 @@ django==3.2.19
     #   openedx-events
     #   openedx-ledger
     #   social-auth-app-django
+django-clearcache==1.2.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 django-cors-headers==4.0.0
     # via
     #   -r requirements/quality.txt
@@ -269,7 +274,7 @@ fastavro==1.7.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.12.0
+filelock==3.12.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -350,7 +355,7 @@ lazy-object-proxy==1.9.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via
     #   -r requirements/quality.txt
     #   rich
@@ -423,7 +428,7 @@ pkgutil-resolve-name==1.3.10
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -516,7 +521,7 @@ pyrsistent==0.19.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jsonschema
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -603,7 +608,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==13.4.1
+rich==13.4.2
     # via
     #   -r requirements/quality.txt
     #   twine


### PR DESCRIPTION
### Description
This PR adds the ability to clear cache from the django admin screen similar to enterprise-catalog. Very useful for QAing data that may be cached and need to be updated real time (e.g. varient_id)

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
