### PR TITLE
fix: properly parsing datetime strings with decimals seconds

### DIFF
--- a/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py
+++ b/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py
@@ -46,6 +46,16 @@ class Command(BaseCommand):
             ),
         )
 
+    def convert_unenrollment_datetime_string(self, datetime_str):
+        """
+        Helper method to strip microseconds from a datetime object
+        """
+        try:
+            formatted_datetime = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%SZ")
+        except ValueError:
+            formatted_datetime = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+        return formatted_datetime
+
     def unenrollment_can_be_refunded(
         self,
         content_metadata,
@@ -75,15 +85,10 @@ class Command(BaseCommand):
         # ie MAX(enterprise enrollment created at, course start date) + 14 days > unenrolled_at date
         enrollment_created_at = enterprise_course_enrollment.get("created")
         enrollment_unenrolled_at = enterprise_course_enrollment.get("unenrolled_at")
-        enrollment_created_datetime = datetime.strptime(
-            enrollment_created_at, "%Y-%m-%dT%H:%M:%SZ"
-        )
-        course_start_datetime = datetime.strptime(
-            course_start_date, "%Y-%m-%dT%H:%M:%SZ"
-        )
-        enrollment_unenrolled_at_datetime = datetime.strptime(
-            enrollment_unenrolled_at, "%Y-%m-%dT%H:%M:%SZ"
-        )
+
+        enrollment_created_datetime = self.convert_unenrollment_datetime_string(enrollment_created_at)
+        course_start_datetime = self.convert_unenrollment_datetime_string(course_start_date)
+        enrollment_unenrolled_at_datetime = self.convert_unenrollment_datetime_string(enrollment_unenrolled_at)
         refund_cutoff_date = max(course_start_datetime, enrollment_created_datetime) + timedelta(days=14)
 
         if refund_cutoff_date > enrollment_unenrolled_at_datetime:


### PR DESCRIPTION
### Description
we're seeing the follow logs when attempting to unenroll

```
2023-06-14 12:34:54,863 INFO 1 [enterprise_subsidy.apps.transaction.management.commands.write_reversals_from_enterprise_unenrollments] [user None] [ip None] [request_id None] write_reversals_from_enterprise_unenrollments.py:212 - Updating and writing Transaction Reversals from recent Enterprise unenrollments data
2023-06-14 12:34:55,270 INFO 1 [enterprise_subsidy.apps.transaction.management.commands.write_reversals_from_enterprise_unenrollments] [user None] [ip None] [request_id None] write_reversals_from_enterprise_unenrollments.py:217 - Found 1 recent Enterprise unenrollments
2023-06-14 12:34:55,381 INFO 1 [enterprise_subsidy.apps.transaction.management.commands.write_reversals_from_enterprise_unenrollments] [user None] [ip None] [request_id None] write_reversals_from_enterprise_unenrollments.py:134 - No existing Reversal found for enterprise fulfillment: 2f22308c-6abd-42ae-aece-959570250ffe. Writing Reversal for Transaction: Transaction object (877880e9-d4d7-4fcc-9ec3-b05daf5704d1).
2023-06-14 12:34:55,461 INFO 1 [enterprise_subsidy.apps.content_metadata.api] [user None] [ip None] [request_id None] api.py:212 - [CONTENT METADATA CACHE HIT] for key 5269d4dd7f2c656c6b0da6b4023353f7b59b7a1a00c846827f97febc2392d47337525d8fba2e106c210a2a2f3364ac3407bc602774a5e6046383acb0964eaa0c
Traceback (most recent call last):
  File "/edx/app/enterprise-subsidy/manage.py", line 29, in <module>
    execute_from_command_line(sys.argv)
  File "/edx/venvs/enterprise-subsidy/lib/python3.8/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/edx/venvs/enterprise-subsidy/lib/python3.8/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/venvs/enterprise-subsidy/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 989, in _nr_wrapper_BaseCommand_run_from_argv_
    return wrapped(*args, **kwargs)
  File "/edx/venvs/enterprise-subsidy/lib/python3.8/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/venvs/enterprise-subsidy/lib/python3.8/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/edx/venvs/enterprise-subsidy/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 154, in literal_wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/enterprise-subsidy/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py", line 223, in handle
    reversals_processed += self.handle_reversing_enterprise_course_unenrollment(unenrollment)
  File "/edx/app/enterprise-subsidy/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py", line 171, in handle_reversing_enterprise_course_unenrollment
    if not self.unenrollment_can_be_refunded(content_metadata, enterprise_course_enrollment):
  File "/edx/app/enterprise-subsidy/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py", line 78, in unenrollment_can_be_refunded
    enrollment_created_datetime = datetime.strptime(
  File "/usr/lib/python3.8/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/lib/python3.8/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '2023-06-06T21:07:51.818519Z' does not match format '%Y-%m-%dT%H:%M:%SZ'
```

we need to properly handle when our datetime strings have microseconds 

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
