### PR TITLE
feat: Adds support for filter and sort to Subsidy API

### DIFF
--- a/enterprise_subsidy/apps/api/paginators.py
+++ b/enterprise_subsidy/apps/api/paginators.py
@@ -1,6 +1,8 @@
 """
 Customer paginators for the subsidy API.
 """
+from math import ceil
+
 from rest_framework import pagination
 
 from ..subsidy.models import Subsidy
@@ -39,4 +41,32 @@ class TransactionListPaginator(pagination.PageNumberPagination):
                 "total_quantity": self.total_quantity,
             }
             paginated_response.data['aggregates'] = aggregates
+        return paginated_response
+
+
+class SubsidyListPaginator(pagination.PageNumberPagination):
+    """
+    Adds a computer 'page_count' number to the base pagination response
+    of subsidy list views.
+    """
+    page_size = 10
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.page_count = 0
+        self.page_size_query_param = None
+
+    def paginate_queryset(self, queryset, request, view=None):
+        self.page_count = Subsidy.objects.count()
+        self.page_size_query_param = request.query_params.get('page_size') or self.page_size
+        return super().paginate_queryset(queryset, request, view)
+
+    def get_paginated_response(self, data):
+        """
+        Adds an attribute of page_count to be used for the support-tools subsidy table
+        """
+        paginated_response = super().get_paginated_response(data)
+        paginated_response.data['page_count'] = ceil(self.page_count / int(self.page_size_query_param))
         return paginated_response

--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -170,6 +170,62 @@ class SubsidyViewSetTests(APITestBase):
         }
         self.assertEqual(expected_result, response.json())
 
+    def test_get_subsidy_list_as_admin(self):
+        """"
+        Test that a subsidy list call returns the expected
+        serialized response.
+        """
+        self.set_up_admin(enterprise_uuids=[self.subsidy_1.enterprise_customer_uuid])
+        response = self.client.get(self.get_list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['count'], 2)
+        self.assertEqual(len(response.json()['results']), response.json()['count'])
+
+    def test_get_subsidy_list_as_operator(self):
+        """"
+        Test that a subsidy list call returns the expected
+        serialized response.
+        """
+        self.set_up_operator()
+        response = self.client.get(self.get_list_url)
+        print(response.json()['results'][0]['uuid'].find(str(self.subsidy_1.uuid)))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['count'], 3)
+        self.assertEqual(len(response.json()['results']), response.json()['count'])
+
+    def test_get_subsidy_list_with_query_parameter_enterprise_customer_uuid(self):
+        """"
+        Test that a subsidy list call returns the expected
+        serialized response filtering by the enterprise customer uuid.
+        """
+        self.set_up_admin(enterprise_uuids=[self.subsidy_1.enterprise_customer_uuid])
+        response = self.client.get(self.get_list_url, data={'enterprise_customer_uuid': self.enterprise_1_uuid})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['count'], 2)
+        self.assertEqual(len(response.json()['results']), response.json()['count'])
+
+    def test_get_subsidy_list_with_query_parameter_subsidy_uuid(self):
+        """"
+        Test that a subsidy list call returns the expected
+        serialized response filtering by the subsidy uuid.
+        """
+        self.set_up_admin(enterprise_uuids=[self.subsidy_1.enterprise_customer_uuid])
+        response = self.client.get(self.get_list_url, data={'uuid': self.subsidy_1_uuid})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['count'], 1)
+        self.assertEqual(len(response.json()['results']), response.json()['count'])
+
+    def test_get_subsidy_list_with_query_parameter_subsidy_title(self):
+        """"
+        Test that a subsidy list call returns the expected
+        serialized response filtering by the subsidy uuid.
+        """
+        self.set_up_admin(enterprise_uuids=[self.subsidy_1.enterprise_customer_uuid])
+        response = self.client.get(self.get_list_url, data={'title': self.subsidy_1.title})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['count'], 1)
+        self.assertEqual(len(response.json()['results']), response.json()['count'])
+
     def test_get_one_subsidy_learner_not_allowed(self):
         """
         Test that learner roles do not allow access to read subsidies.

--- a/enterprise_subsidy/apps/api/v1/utils.py
+++ b/enterprise_subsidy/apps/api/v1/utils.py
@@ -33,3 +33,22 @@ def get_enterprise_uuid_from_request_query_params(request):
         return uuid.UUID(enterprise_customer_uuid)
     except ValueError as exc:
         raise ParseError(f'{enterprise_customer_uuid} is not a valid uuid.') from exc
+
+
+def get_subsidy_uuid_from_request_query_params(request):
+    """
+    Returns the subsidy UUID from the ``uuid`` query parameter.
+
+    Returns:
+        uuid.UUID: The UUID of the subsidy, or None if the query parameter is not present.
+
+    Raises:
+        rest_framework.exceptions.ParseError: If the requested UUID string is not parseable.
+    """
+    subsidy_uuid = request.query_params.get('uuid')
+    if not subsidy_uuid:
+        return None
+    try:
+        return uuid.UUID(subsidy_uuid)
+    except ValueError as exc:
+        raise ParseError(f'{subsidy_uuid} is not a valid uuid.') from exc


### PR DESCRIPTION
Adds support for filtering and sorting of subsidies.
Adds `page_count` on paginated data. 
Allows for `page_size` query parameter

Added to support this [ticket](https://2u-internal.atlassian.net/browse/ENT-6942) and [PR](https://github.com/openedx/frontend-app-support-tools/pull/343)

Tests are WIP

### Description
Describe in a couple of sentences what this PR adds

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
