### PR TITLE
fix: update 'api-docs/' endpoint

### DIFF
--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -328,7 +328,7 @@ JWT_AUTH = {
 # Request the user's permissions in the ID token
 EXTRA_SCOPE = ['permissions']
 
-LOGIN_REDIRECT_URL = '/api-docs/'
+LOGIN_REDIRECT_URL = '/api/schema/swagger-ui/'
 # END AUTHENTICATION CONFIGURATION
 
 # Set up system-to-feature roles mapping for edx-rbac.

--- a/enterprise_subsidy/urls.py
+++ b/enterprise_subsidy/urls.py
@@ -57,13 +57,10 @@ urlpatterns = oauth2_urlpatterns + [
     re_path(r'^admin/clearcache/', include('clearcache.urls')),
     re_path(r'^admin/', admin.site.urls),
     re_path(r'^api/', include(api_urls)),
-    re_path(r'^api-docs(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
-    re_path(r'^api-docs/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     re_path(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     re_path(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
     re_path(r'^health/$', core_views.health, name='health'),
     # DRF-spectacular routes below
-    # TODO: deprecate the `/api-docs/` route in favor of the routes below.
     path('api/schema/', spectacular_view.as_view(), name='schema'),
     path('api/schema/swagger-ui/', spec_swagger_view.as_view(url_name='schema'), name='swagger-ui'),
     path('api/schema/redoc/', spec_redoc_view.as_view(url_name='schema'), name='redoc'),


### PR DESCRIPTION
Update api-docs endpoint to point to `SpectacularSwaggerView` view. 

### Description
Describe in a couple of sentences what this PR adds

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
