### PR TITLE
chore: only allow course unenrollment if transaction is committed

### DIFF
--- a/enterprise_subsidy/apps/transaction/views.py
+++ b/enterprise_subsidy/apps/transaction/views.py
@@ -8,7 +8,7 @@ from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.generic import View
-from openedx_ledger.models import Transaction
+from openedx_ledger.models import Transaction, TransactionStateChoices
 
 from enterprise_subsidy.apps.api_client.enterprise import EnterpriseApiClient
 
@@ -38,6 +38,9 @@ class UnenrollLearnersView(View):
         if not transaction:
             logger.info(f"UnenrollLearnersView: transaction {transaction_id} not found, skipping")
             return HttpResponseBadRequest("Transaction not found")
+        if transaction.state != TransactionStateChoices.COMMITTED:
+            logger.info(f"transaction {transaction_id} is not committed, skipping")
+            return HttpResponseBadRequest("Transaction is not committed")
         if not transaction.fulfillment_identifier:
             logger.info(f"UnenrollLearnersView: transaction {transaction_id} has no fulfillment uuid, skipping")
             return HttpResponseBadRequest("Transaction has no associated platform fulfillment identifier")
@@ -60,6 +63,9 @@ class UnenrollLearnersView(View):
         if not transaction:
             logger.info(f"transaction {transaction_id} not found, skipping")
             return HttpResponseBadRequest("Transaction not found")
+        if transaction.state != TransactionStateChoices.COMMITTED:
+            logger.info(f"transaction {transaction_id} is not committed, skipping")
+            return HttpResponseBadRequest("Transaction is not committed")
         if not transaction.fulfillment_identifier:
             logger.info(f"transaction {transaction_id} has no fulfillment uuid, skipping")
             return HttpResponseBadRequest("Transaction has no associated platform fulfillment identifier")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -177,7 +177,7 @@ openedx-events==8.0.1
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-openedx-ledger==1.0.1
+openedx-ledger==1.0.2
     # via -r requirements/base.in
 packaging==23.1
     # via drf-yasg

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -345,7 +345,7 @@ openedx-events==8.0.1
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-openedx-ledger==1.0.1
+openedx-ledger==1.0.2
     # via -r requirements/validation.txt
 packaging==23.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -333,7 +333,7 @@ openedx-events==8.0.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==1.0.1
+openedx-ledger==1.0.2
     # via -r requirements/test.txt
 packaging==23.1
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -223,7 +223,7 @@ openedx-events==8.0.1
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==1.0.1
+openedx-ledger==1.0.2
     # via -r requirements/base.txt
 packaging==23.1
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -313,7 +313,7 @@ openedx-events==8.0.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==1.0.1
+openedx-ledger==1.0.2
     # via -r requirements/test.txt
 packaging==23.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -265,7 +265,7 @@ openedx-events==8.0.1
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==1.0.1
+openedx-ledger==1.0.2
     # via -r requirements/base.txt
 packaging==23.1
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -403,7 +403,7 @@ openedx-events==8.0.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==1.0.1
+openedx-ledger==1.0.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description
If a transaction is not in a COMMITTED state, it should not allow unenrolls or reversals. This PR only changes the management system. It would be a corner case for a transaction linked to an enrollment object to be anything but COMMITTED, but this should help if a corner case is encountered.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
