### PR TITLE
build: switch to mysql 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,8 +184,17 @@ dev.stop: # Stops containers so they can be restarted
 app-shell: # Run the app shell as root
 	docker exec -u 0 -it enterprise-subsidy.app bash
 
-db-shell: # Run the app shell as root, enter the app's database
+db-shell-57: # Run the mysql 5.7 shell as root, enter the app's database
 	docker exec -u 0 -it enterprise-subsidy.db mysql -u root enterprise_subsidy
+
+db-shell-8: # Run the mysql 8 shell as root, enter the app's database
+	docker exec -u 0 -it enterprise-subsidy.mysql80 mysql -u root enterprise_subsidy
+
+dev.dbcopy8: ## Copy data from old mysql 5.7 container into a new 8 db
+	mkdir -p .dev/
+	docker-compose exec db bash -c "mysqldump --databases enterprise_subsidy" > .dev/enterprise_subsidy.sql
+	docker-compose exec -T mysql80 bash -c "mysql" < .dev/enterprise_subsidy.sql
+	rm .dev/enterprise_subsidy.sql
 
 %-logs: # View the logs of the specified service container
 	docker-compose logs -f --tail=500 $*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,22 @@ services:
     volumes:
       - enterprise_subsidy_mysql57:/var/lib/mysql
 
+  mysql80:
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
+    container_name: enterprise-subsidy.mysql80
+    environment:
+      MYSQL_ROOT_PASSWORD: ""
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    # Oracle-packaged version includes a `linux/arm64/v8` version, needed for
+    # machines with Apple Silicon CPUs (Mac M1, M2)
+    image: mysql:8.0.33-oracle
+    networks:
+      - devstack_default
+    ports:
+      - "3406:3306"
+    volumes:
+      - enterprise_subsidy_mysql80:/var/lib/mysql
+
   memcache:
     image: memcached:1.4.24
     container_name: enterprise-subsidy.memcache
@@ -47,3 +63,4 @@ networks:
 
 volumes:
   enterprise_subsidy_mysql57:
+  enterprise_subsidy_mysql80:

--- a/enterprise_subsidy/settings/devstack.py
+++ b/enterprise_subsidy/settings/devstack.py
@@ -12,7 +12,7 @@ DATABASES = {
         'NAME': os.environ.get('DB_NAME', 'enterprise_subsidy'),
         'USER': os.environ.get('DB_USER', 'root'),
         'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': os.environ.get('DB_HOST', 'enterprise-subsidy.db'),
+        'HOST': os.environ.get('DB_HOST', 'enterprise-subsidy.mysql80'),
         'PORT': os.environ.get('DB_PORT', 3306),
         'ATOMIC_REQUESTS': False,
         'CONN_MAX_AGE': 60,


### PR DESCRIPTION
### Description
Switch to mysql 8 for devstack development.

### Testing instructions

```
make dev.up
make dev.dbcopy8
make app-restart
```
Then login to the admin site to ensure your data was copied: http://localhost:18280/admin/ 
Note that the new mysql 8 container is running side-by-side with mysql 5.7 for now.  For mysql 8, the container's 3306 port is bound to the host's 3406 port, so use 3406 if you use a mysql IDE or something locally.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
