### PR TITLE
build: don't bind 3406 to the host for mysql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ services:
     image: mysql:8.0.33-oracle
     networks:
       - devstack_default
-    ports:
-      - "3406:3306"
     volumes:
       - enterprise_subsidy_mysql80:/var/lib/mysql
 


### PR DESCRIPTION
### Description
Doing so caused conflicts when other services (e.g. enterprise-access) tried to do the same thing.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
