### PR TITLE
feat: Update prod_requirements Makefile target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 .PHONY: help clean requirements ci_requirements dev_requirements \
-        validation_requirements doc_requirements prod_requirements static shell \
+        validation_requirements doc_requirements production-requirements static shell \
         test coverage isort_check isort style lint quality pii_check validate \
         migrate html_coverage upgrade extract_translation dummy_translations \
         compile_translations fake_translations pull_translations \
@@ -49,7 +49,7 @@ validation_requirements: pip_requirements ## sync to requirements for testing & 
 doc_requirements:
 	pip-sync -q requirements/doc.txt
 
-prod_requirements: ## install requirements for production
+production-requirements: ## install requirements for production
 	pip-sync -q requirements/production.txt
 
 static: ## generate static files


### PR DESCRIPTION
The configuration code expects production-requirements to be the Makefile target name.

https://github.com/openedx/edx-cookiecutters/issues/384

### Description
Describe in a couple of sentences what this PR adds

### Testing instructions

Add some, if applicable

### Merge checklist
- [x] All reviewers approved
- [x] CI build is green
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
