### PR TITLE
fix: get_or_create_learner_credit_subsidy() not idempotent for test records

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -335,7 +335,7 @@ class SubsidyCreationRequestSerializer(serializers.Serializer):
         required=True,
         help_text=(
             "Identifier of the upstream Salesforce object that represents the deal that led to the creation of this "
-            "Subsidy."
+            "Subsidy. For test subsidy records, see the note below about ``default_internal_only``."
         ),
     )
     default_title = serializers.CharField(
@@ -373,7 +373,16 @@ class SubsidyCreationRequestSerializer(serializers.Serializer):
     )
     default_internal_only = serializers.BooleanField(
         required=True,
-        help_text="If set, this subsidy will not be customer facing, nor have any influence on enterprise customers.",
+        help_text=(
+            "If set, this subsidy will not be customer facing, nor have any influence on enterprise customers."
+            "If ``default_internal_only`` is False and an existing subsidy is "
+            "found with the given ``reference_id``, all `default_*` arguments are ignored "
+            "and this view returns that existing record. "
+            "However, when ``default_internal_only`` is True, this view will "
+            "simply create a new record, regardless of any existing records "
+            "with the same ``reference_id`` (we assume that the reference_id is "
+            "essentially meaningless for test subsidy records)."
+        ),
     )
 
 

--- a/enterprise_subsidy/apps/api/v1/views/subsidy.py
+++ b/enterprise_subsidy/apps/api/v1/views/subsidy.py
@@ -267,7 +267,8 @@ class SubsidyViewSet(
     )
     def create(self, request, *args, **kwargs):
         """
-        Get or create a new subsidy
+        Get or create a new subsidy.  See request payload serialization notes
+        around ``default_internal_only`` and the get-or-create operation.
 
         Endpoint Location: POST /api/v1/subsidies/
         """

--- a/enterprise_subsidy/apps/subsidy/api.py
+++ b/enterprise_subsidy/apps/subsidy/api.py
@@ -20,7 +20,13 @@ def get_or_create_learner_credit_subsidy(
     Get or create a new learner credit subsidy and ledger with the given defaults.
 
     Notes:
-        * If an existing subsidy is found with the given `reference_id`, all `default_*` arguments are ignored.
+        * If ``default_internal_only`` is False and an existing subsidy is
+          found with the given ``reference_id``, all `default_*` arguments are ignored
+          and this function returns that existing record.
+          However, when ``default_internal_only`` is True, this function will
+          simply create a new record, regardless of any existing records
+          with the same ``reference_id`` (we assume that the reference_id is
+          essentially meaningless for test subsidy records).
 
     Args:
         reference_id (str): ID of the originating salesforce opportunity product.
@@ -47,10 +53,18 @@ def get_or_create_learner_credit_subsidy(
         'revenue_category': default_revenue_category,
         'internal_only': default_internal_only,
     }
-    subsidy, created = Subsidy.objects.get_or_create(
-        reference_id=reference_id,
-        defaults=subsidy_defaults,
-    )
+    if not default_internal_only:
+        subsidy, created = Subsidy.objects.get_or_create(
+            reference_id=reference_id,
+            defaults=subsidy_defaults,
+        )
+    else:
+        # The record to create is for testing, do a plain ole create()
+        created = True
+        subsidy = Subsidy.objects.create(
+            reference_id=reference_id,
+            **subsidy_defaults,
+        )
     return (subsidy, created)
 
 

--- a/enterprise_subsidy/apps/subsidy/tests/test_api.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_api.py
@@ -59,6 +59,31 @@ def test_get_learner_credit_subsidy(learner_credit_fixture):  # pylint: disable=
     assert learner_credit_fixture.current_balance() == 1000000
 
 
+@pytest.mark.django_db
+def test_create_internal_only_subsidy_record(learner_credit_fixture):  # pylint: disable=redefined-outer-name
+    """
+    Test that an internal-only Subsidy record can be created
+    even if one with the same reference_id already exists.
+    """
+    other_customer_uuid = uuid4()
+    new_subsidy, created = subsidy_api.get_or_create_learner_credit_subsidy(
+        reference_id=learner_credit_fixture.reference_id,
+        default_title="Default Title",
+        default_enterprise_customer_uuid=other_customer_uuid,
+        default_unit=UnitChoices.USD_CENTS,
+        default_starting_balance=42,
+        default_active_datetime=None,
+        default_expiration_datetime=None,
+        default_internal_only=True
+    )
+    assert created
+    assert new_subsidy.current_balance() == 42
+    assert new_subsidy.reference_id == learner_credit_fixture.reference_id
+    assert new_subsidy.title == 'Default Title'
+    assert new_subsidy.enterprise_customer_uuid == other_customer_uuid
+    assert learner_credit_fixture.current_balance() == 1000000
+
+
 class CanRedeemTestCase(TestCase):
     """
     Test the can_redeem() function.


### PR DESCRIPTION
Modify the mentioned function such that, if ``default_internal_only`` is False and an existing subsidy is found with the given ``reference_id``, all `default_*` arguments are ignored and this function returns that existing record.
However, when ``default_internal_only`` is True, this function will simply create a new record, regardless of any existing records with the same ``reference_id`` (we assume that the reference_id is essentially meaningless for test subsidy records). 
ENT-7799

API docs now reflect this nuance: http://localhost:18280/api/schema/redoc/#tag/subsidy/operation/api_v1_subsidies_create

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
