### PR TITLE
feat: additional Transaction fields

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -128,7 +128,9 @@ class TransactionSerializer(serializers.ModelSerializer):
             "state",
             "idempotency_key",
             "lms_user_id",
+            "lms_user_email",
             "content_key",
+            "content_title",
             "quantity",
             "unit",  # Manually fetch from parent ledger via get_unit().
             "fulfillment_identifier",

--- a/enterprise_subsidy/apps/api_client/lms_user.py
+++ b/enterprise_subsidy/apps/api_client/lms_user.py
@@ -1,0 +1,81 @@
+"""
+LMS User Data api client for the subsidy service.
+"""
+import logging
+
+import requests
+from django.conf import settings
+from django.core.cache import cache
+
+from enterprise_subsidy.apps.api_client.base_oauth import BaseOAuthClient
+
+logger = logging.getLogger(__name__)
+
+
+class LmsUserApiClient(BaseOAuthClient):
+    """
+    API client for LMS User Data.
+    """
+    api_base_url = settings.LMS_URL + '/api/user/v1'
+    accounts_url = api_base_url + '/accounts'
+
+    def user_account_url(self, lms_user_id):
+        return f"{self.accounts_url}?lms_user_id={lms_user_id}"
+
+    def get_user_data(self, lms_user_id):
+        """
+        Gets the data for an LMS User given their lms user id.
+
+        Arguments:
+            lms_user_id (int): LMS User Id of a learner
+        Returns:
+            response (dict): JSON response data
+        Raises:
+            requests.exceptions.HTTPError: if service is down/unavailable or status code comes back >= 300,
+            the method will log and throw an HTTPError exception.
+        """
+        lms_account_url = self.user_account_url(lms_user_id)
+        try:
+            response = self.client.get(lms_account_url)
+            response.raise_for_status()
+            data = response.json()
+            if data:
+                return data.pop()
+            else:
+                return None
+        except requests.exceptions.HTTPError as exc:
+            if hasattr(response, 'text'):
+                logger.error(
+                    f'Failed to fetch user data for {lms_user_id} because {response.text}',
+                )
+            raise exc
+
+    def best_effort_user_data(self, lms_user_id):
+        """
+        Gets the data for an LMS User given their lms user id.
+        Tries to use cache.
+        Rescues exceptions + logs without reraising.
+
+        Arguments:
+            lms_user_id (int): LMS User Id of a learner
+        Returns:
+            response (dict): JSON response data
+        """
+        try:
+            cache_key = 'LmsUserApiClient:lms_user_id:{lms_user_id}'.format(lms_user_id=lms_user_id)
+            user_data = cache.get(cache_key)
+
+            if not isinstance(user_data, dict):
+                user_data = self.get_user_data(lms_user_id)
+
+                if not isinstance(user_data, dict):
+                    logger.warning('Received unexpected user_data for lms_user_id %s', lms_user_id)
+                    return None
+
+                cache.set(cache_key, user_data, settings.LMS_USER_DATA_CACHE_TIMEOUT)
+            return user_data
+        except requests.exceptions.HTTPError:
+            logger.exception(
+                f'Failed best effort attempt to fetch user data for {lms_user_id}',
+            )
+            return None

--- a/enterprise_subsidy/apps/api_client/tests/test_lms_user.py
+++ b/enterprise_subsidy/apps/api_client/tests/test_lms_user.py
@@ -1,0 +1,81 @@
+from unittest import mock
+
+import ddt
+from django.test import TestCase
+from requests.exceptions import HTTPError
+
+from enterprise_subsidy.apps.api_client.lms_user import LmsUserApiClient
+from test_utils.utils import MockResponse
+
+
+@ddt.ddt
+class LmsUserApiClientTests(TestCase):
+    """
+    Tests for the lms user api client.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user_id = 12345
+        cls.user_email = 'user@example.com'
+
+    @mock.patch('enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient', return_value=mock.MagicMock())
+    def test_successful_get_user_data(self, mock_oauth_client):
+        """
+        Test the happy path of getting user data from the lms
+        """
+        mock_oauth_client.return_value.get.return_value = MockResponse(
+            [{
+                "name": "Example User",
+                "email": "user@example.com",
+                "id": 12345,
+            }],
+            200,
+        )
+        lms_user_client = LmsUserApiClient()
+        response = lms_user_client.get_user_data(self.user_id)
+        assert response.get('id') == self.user_id
+        mock_oauth_client().get.assert_called_with(
+            f'{LmsUserApiClient.accounts_url}?lms_user_id={self.user_id}'
+        )
+
+    @mock.patch('enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient', return_value=mock.MagicMock())
+    def test_failed_get_user_data(self, mock_oauth_client):
+        """
+        Test the when something fails getting user data from the lms
+        """
+        mock_oauth_client.return_value.get.return_value = MockResponse(None, 400)
+        lms_user_client = LmsUserApiClient()
+        with self.assertRaises(HTTPError):
+            lms_user_client.get_user_data(self.user_id)
+
+    @mock.patch('enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient', return_value=mock.MagicMock())
+    def test_successful_best_effort_user_data(self, mock_oauth_client):
+        """
+        Test the happy path of the best effort version
+        """
+        mock_oauth_client.return_value.get.return_value = MockResponse(
+            [{
+                "name": "Example User",
+                "email": "user@example.com",
+                "id": 12345,
+            }],
+            200,
+        )
+        lms_user_client = LmsUserApiClient()
+        response = lms_user_client.best_effort_user_data(self.user_id)
+        assert response.get('id') == self.user_id
+        mock_oauth_client().get.assert_called_with(
+            f'{LmsUserApiClient.accounts_url}?lms_user_id={self.user_id}'
+        )
+
+    @mock.patch('enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient', return_value=mock.MagicMock())
+    def test_failed_best_effort_user_data(self, mock_oauth_client):
+        """
+        Test the that the best effort version fails without exception
+        """
+        mock_oauth_client.return_value.get.return_value = MockResponse(None, 400)
+        lms_user_client = LmsUserApiClient()
+        response = lms_user_client.best_effort_user_data(self.user_id)
+        assert response is None

--- a/enterprise_subsidy/apps/subsidy/tests/test_models.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_models.py
@@ -198,6 +198,8 @@ class SubsidyModelRedemptionTestCase(TestCase):
         self.subsidy = SubsidyFactory.create(
             enterprise_customer_uuid=self.enterprise_customer_uuid,
         )
+        self.subsidy.lms_user_client = mock.MagicMock()
+        self.subsidy.lms_user_client.return_value.best_effort_user_data.return_value = {'email': 'edx@example.com'}
         super().setUp()
 
     def test_get_committed_transaction_no_reversal(self):
@@ -300,6 +302,7 @@ class SubsidyModelRedemptionTestCase(TestCase):
         mock_get_content_summary.return_value = {
             'content_uuid': 'course-v1:edX+test+course',
             'content_key': 'course-v1:edX+test+course',
+            'content_title': 'edx: Test Course',
             'source': 'edX',
             'mode': 'verified',
             'content_price': 10000,

--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -364,3 +364,8 @@ CONTENT_METADATA_VIEW_CACHE_TIMEOUT_SECONDS = 60 * 15
 
 # disable indexing on history_date
 SIMPLE_HISTORY_DATE_INDEX = False
+
+
+# How long we keep API Client data in cache. (seconds)
+ONE_HOUR = 60 * 60
+LMS_USER_DATA_CACHE_TIMEOUT = ONE_HOUR

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -173,7 +173,7 @@ openedx-events==8.6.0
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-openedx-ledger==1.2.0
+openedx-ledger==1.3.2
     # via -r requirements/base.in
 packaging==23.2
     # via drf-yasg

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -344,7 +344,7 @@ openedx-events==8.6.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-openedx-ledger==1.2.0
+openedx-ledger==1.3.2
     # via -r requirements/validation.txt
 packaging==23.2
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -331,7 +331,7 @@ openedx-events==8.6.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==1.2.0
+openedx-ledger==1.3.2
     # via -r requirements/test.txt
 packaging==23.2
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -213,7 +213,7 @@ openedx-events==8.6.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==1.2.0
+openedx-ledger==1.3.2
     # via -r requirements/base.txt
 packaging==23.2
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -310,7 +310,7 @@ openedx-events==8.6.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==1.2.0
+openedx-ledger==1.3.2
     # via -r requirements/test.txt
 packaging==23.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -258,7 +258,7 @@ openedx-events==8.6.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-openedx-ledger==1.2.0
+openedx-ledger==1.3.2
     # via -r requirements/base.txt
 packaging==23.2
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -399,7 +399,7 @@ openedx-events==8.6.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-openedx-ledger==1.2.0
+openedx-ledger==1.3.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description
- populates `lms_user_email` and `content_title` on new `Transactions`
- i will follow with a management command to back-fill existing transaction data later
- https://2u-internal.atlassian.net/browse/ENT-7867
- https://2u-internal.atlassian.net/browse/ENT-7868

