### PR TITLE
perf: select_related and prefetch_related in transactions APIs

### DIFF
--- a/enterprise_subsidy/apps/api/v1/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v1/views/transaction.py
@@ -254,7 +254,18 @@ class TransactionViewSet(
         #
         # Finally, overlay both `user_id`-based and request-parameter-based filters in to one big happy queryset.
         #
-        return queryset.filter(**request_based_kwargs).order_by("uuid")
+        return queryset.filter(
+            **request_based_kwargs,
+        ).select_related(
+            "ledger",
+            "ledger__subsidy",
+            "reversal",
+        ).prefetch_related(
+            "external_reference",
+            "external_reference__external_fulfillment_provider",
+        ).order_by(
+            "uuid",
+        )
 
     def retrieve(self, request, *args, **kwargs):  # pylint: disable=useless-parent-delegation
         """

--- a/enterprise_subsidy/apps/api/v2/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v2/views/transaction.py
@@ -63,11 +63,15 @@ class TransactionBaseViewMixin:
     def get_queryset(self):
         """
         A base queryset that selects all transaction records (along with their
-        associated ledger and subsidy) for the requested ``subsidy_uuid``.
+        associated ledger, subsidy, reversals, and external references) for the requested ``subsidy_uuid``.
         """
         return Transaction.objects.select_related(
             'ledger',
             'ledger__subsidy',
+            'reversal',
+        ).prefetch_related(
+            'external_reference',
+            'external_reference__external_fulfillment_provider',
         ).filter(
             ledger__subsidy=self.subsidy
         )


### PR DESCRIPTION
### Description
We're doing many small selects of related reversals and external references in our transaction list APIs.  This PR selects/prefetches the related records.  This should provide a moderate improvement in performance of these APIs.

### Testing instructions

TODO

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
