### PR TITLE
test: add test for content-metdata retrieve without customer query param

### DIFF
--- a/enterprise_subsidy/apps/api/schema.py
+++ b/enterprise_subsidy/apps/api/schema.py
@@ -32,6 +32,16 @@ class Parameters:
             "The content key/identifier to which the query pertains."
         ),
     )
+    ENTERPRISE_CUSTOMER_UUID = OpenApiParameter(
+        'enterprise_customer_uuid',
+        type=OpenApiTypes.UUID,
+        location=OpenApiParameter.QUERY,
+        required=True,
+        allow_blank=False,
+        description=(
+            "The UUID associated with the requesting user's enterprise customer."
+        ),
+    )
 
 
 def _open_api_error_response(exception_class, detail_str, example_name):

--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -1461,12 +1461,24 @@ class ContentMetadataViewSetTests(APITestBase):
                 'geag_variant_id': expected_geag_variant_id,
             }
 
-    def test_failure_no_permission(self):
+    def test_retrieve_failure_no_permission(self):
         self.set_up_admin(enterprise_uuids=[str(uuid.uuid4())])
         url = reverse('api:v1:content-metadata', kwargs={'content_identifier': self.content_key_1})
         response = self.client.get(url + f'?enterprise_customer_uuid={str(uuid.uuid4())}')
         assert response.status_code == 403
         assert response.json() == {'detail': 'MISSING: subsidy.can_read_metadata'}
+
+    def test_retrieve_failure_no_query_param(self):
+        """
+        When no `enterprise_customer_uuid` query param is supplied by the requesting operator, test response is 400.
+        """
+        self.set_up_operator()
+        url = reverse('api:v1:content-metadata', kwargs={'content_identifier': self.content_key_1})
+        response = self.client.get(url)
+        assert response.status_code == 400
+        assert response.json() == [
+            'You must provide at least one of the following query parameters: enterprise_customer_uuid.'
+        ]
 
     @ddt.data(
         {

--- a/enterprise_subsidy/apps/api/v1/views/content_metadata.py
+++ b/enterprise_subsidy/apps/api/v1/views/content_metadata.py
@@ -7,6 +7,7 @@ import requests
 from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
+from drf_spectacular.utils import extend_schema
 from edx_rbac.mixins import PermissionRequiredMixin
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import permissions
@@ -26,6 +27,8 @@ from enterprise_subsidy.apps.subsidy.constants import (
     PERMISSION_CAN_READ_CONTENT_METADATA
 )
 from enterprise_subsidy.apps.subsidy.models import EnterpriseSubsidyRoleAssignment
+
+from ...schema import Parameters
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +82,7 @@ class ContentMetadataViewSet(
         """
         return utils.get_enterprise_uuid_from_request_query_params(self.request)
 
+    @extend_schema(parameters=[Parameters.ENTERPRISE_CUSTOMER_UUID])
     @method_decorator(cache_page(CONTENT_METADATA_VIEW_CACHE_TIMEOUT_SECONDS))
     @method_decorator(require_at_least_one_query_parameter('enterprise_customer_uuid'))
     @action(detail=True)


### PR DESCRIPTION
ENT-7788

### Description

Ticket with context: https://2u-internal.atlassian.net/browse/ENT-7788

> noticed that it looks like ContentMetadataViewSet in enterprise-subsidy throws a 500 when it's called without the enterprise_customer_uuid query parameter

I was unable to reproduce this issue, as the response was 403 when no parameter was supplied (and supplying the parameter returns a 200).  For completeness, I added a unit test to make sure the response is 403.