### PR TITLE
feat: skip customer fetch in content_metadata view

### DIFF
--- a/enterprise_subsidy/apps/api/v1/views/content_metadata.py
+++ b/enterprise_subsidy/apps/api/v1/views/content_metadata.py
@@ -106,7 +106,8 @@ class ContentMetadataViewSet(
         try:
             content_summary = self.content_metadata_api().get_content_summary(
                 enterprise_customer_uuid[0],
-                content_identifier
+                content_identifier,
+                skip_customer_fetch=True,
             )
             if not content_summary.get('content_price'):
                 logger.warning(f"Could not find course price in metadata for {content_identifier}")

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -136,13 +136,14 @@ class ContentMetadataApi:
                 return course_run
         return {}
 
-    def get_content_summary(self, enterprise_customer_uuid, content_identifier):
+    def get_content_summary(self, enterprise_customer_uuid, content_identifier, **kwargs):
         """
         Returns a summary dict some content metadata, makes the client call
         """
         course_details = self.get_content_metadata(
             enterprise_customer_uuid,
-            content_identifier
+            content_identifier,
+            **kwargs,
         )
         return self.summary_data_for_content(content_identifier, course_details)
 
@@ -201,7 +202,7 @@ class ContentMetadataApi:
         return self.get_content_summary(enterprise_customer_uuid, content_identifier).get('geag_variant_id')
 
     @staticmethod
-    def get_content_metadata(enterprise_customer_uuid, content_identifier):
+    def get_content_metadata(enterprise_customer_uuid, content_identifier, **kwargs):
         """
         Fetches details about the given content from a tiered (request + django) cache;
         or it fetches from the enterprise-catalog API if not present in the cache,
@@ -214,7 +215,8 @@ class ContentMetadataApi:
 
         course_details = EnterpriseCatalogApiClient().get_content_metadata_for_customer(
             enterprise_customer_uuid,
-            content_identifier
+            content_identifier,
+            **kwargs,
         )
         if course_details:
             TieredCache.set_all_tiers(

--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -360,7 +360,7 @@ ALLOW_LEDGER_MODIFICATION = False
 
 # per-view cache timeout settings
 # We can disable caching on this view by setting the value below to 0.
-CONTENT_METADATA_VIEW_CACHE_TIMEOUT_SECONDS = 60
+CONTENT_METADATA_VIEW_CACHE_TIMEOUT_SECONDS = 60 * 15
 
 # disable indexing on history_date
 SIMPLE_HISTORY_DATE_INDEX = False


### PR DESCRIPTION
### Description
Include the `skip_customer_fetch` param on calls to fetch customer content metadata. See https://github.com/openedx/enterprise-catalog/pull/702

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
