### PR TITLE
fix: validate subsidy uniqueness with clean() method.

### DIFF
--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -156,7 +156,7 @@ class SubsidyViewSetTests(APITestBase):
         expected_result = {
             "uuid": str(self.subsidy_1.uuid),
             "title": self.subsidy_1.title,
-            "enterprise_customer_uuid": self.subsidy_1.enterprise_customer_uuid,
+            "enterprise_customer_uuid": str(self.subsidy_1.enterprise_customer_uuid),
             "active_datetime": self.subsidy_1.active_datetime.strftime(SERIALIZED_DATE_PATTERN),
             "expiration_datetime": self.subsidy_1.expiration_datetime.strftime(SERIALIZED_DATE_PATTERN),
             "unit": self.subsidy_1.unit,

--- a/enterprise_subsidy/apps/subsidy/tests/test_api.py
+++ b/enterprise_subsidy/apps/subsidy/tests/test_api.py
@@ -1,11 +1,13 @@
 """
 Tests for functions defined in the ``api.py`` module.
 """
+from datetime import timedelta
 from unittest import mock
 from uuid import uuid4
 
 import pytest
 from django.test import TestCase
+from django.utils import timezone
 from openedx_ledger.models import Reversal, TransactionStateChoices, UnitChoices
 from openedx_ledger.test_utils.factories import TransactionFactory
 
@@ -25,8 +27,8 @@ def learner_credit_fixture():
         default_enterprise_customer_uuid=uuid4(),
         default_unit=UnitChoices.USD_CENTS,
         default_starting_balance=1000000,
-        default_active_datetime=None,
-        default_expiration_datetime=None,
+        default_active_datetime=timezone.now() - timedelta(days=365),
+        default_expiration_datetime=timezone.now() + timedelta(days=365),
     )
     return subsidy
 
@@ -72,8 +74,8 @@ def test_create_internal_only_subsidy_record(learner_credit_fixture):  # pylint:
         default_enterprise_customer_uuid=other_customer_uuid,
         default_unit=UnitChoices.USD_CENTS,
         default_starting_balance=42,
-        default_active_datetime=None,
-        default_expiration_datetime=None,
+        default_active_datetime=timezone.now() - timedelta(days=365),
+        default_expiration_datetime=timezone.now() + timedelta(days=365),
         default_internal_only=True
     )
     assert created


### PR DESCRIPTION
Use a clean method to validate that non-internal-only subsidies must be unique on (reference_id, reference_type), since mysql does not support conditional unique constraints. ENT-7891

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
