### PR TITLE
chore: fix upgrade requirements github action

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -12,7 +12,7 @@ on:
 jobs:
    call-upgrade-python-requirements-workflow:
     with:
-       branch: ${{ github.event.inputs.branch }}
+       branch: ${{ github.event.inputs.branch || main }}
        # team_reviewers: ""
        # email_address: email@edx.org
        send_success_notification: false


### PR DESCRIPTION
Description:
Currently upgrade automation is failing as it's trying to pull from a `master` branch but that doesn't exist in this repo. I've switch this to `main` as it does not seem that the automation is picking up the variable from the job execution.

Cribbed from here: https://github.com/openedx/edx-analytics-dashboard/blob/2e7b2dc8ad07d8d133ee9d008ce479dd4121bd9b/.github/workflows/upgrade-python-requirements.yml#L14
