### PR TITLE
feat: search transactions by learner email and content title

### DIFF
--- a/enterprise_subsidy/apps/api/v1/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v1/views/transaction.py
@@ -12,7 +12,7 @@ from edx_rbac.mixins import PermissionRequiredForListingMixin
 from edx_rbac.utils import ALL_ACCESS_CONTEXT, contexts_accessible_from_jwt
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from openedx_ledger.models import LedgerLockAttemptFailed, Transaction
-from rest_framework import mixins, permissions, status, viewsets
+from rest_framework import filters, mixins, permissions, status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
@@ -65,6 +65,10 @@ class TransactionViewSet(
     lookup_field = "uuid"
     serializer_class = TransactionSerializer
     pagination_class = TransactionListPaginator
+    filter_backends = [filters.SearchFilter]
+
+    # fields that are queried for search
+    search_fields = ['lms_user_email', 'content_title']
 
     # Fields that control permissions for 'list' actions, required by PermissionRequiredForListingMixin.
     list_lookup_field = "ledger__subsidy__enterprise_customer_uuid"

--- a/enterprise_subsidy/apps/api/v2/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v2/views/transaction.py
@@ -10,7 +10,7 @@ from edx_rbac.decorators import permission_required
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from openedx_ledger.models import LedgerLockAttemptFailed, Transaction
 from requests.exceptions import HTTPError
-from rest_framework import generics, permissions, status
+from rest_framework import filters, generics, permissions, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import APIException, NotFound, PermissionDenied, Throttled
 
@@ -83,8 +83,11 @@ class TransactionAdminListCreate(TransactionBaseViewMixin, generics.ListCreateAP
     of the related subsidy's enterprise customer.  It lists all transactions
     for the requested subsidy, or a subset thereof, depending on the query parameters.
     """
-    filter_backends = [drf_filters.DjangoFilterBackend]
+    filter_backends = [drf_filters.DjangoFilterBackend, filters.SearchFilter]
     filterset_class = TransactionAdminFilterSet
+
+    # fields that are queried for search
+    search_fields = ['lms_user_email', 'content_title']
 
     def __init__(self, *args, **kwargs):
         self.extra_context = {}


### PR DESCRIPTION
### Description

- DRF search on Transactions list
- search fields include learner email address and content title
- https://2u-internal.atlassian.net/browse/ENT-7683

