### PR TITLE
feat: transaction api ordering

### DIFF
--- a/enterprise_subsidy/apps/api/v1/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v1/views/transaction.py
@@ -65,10 +65,16 @@ class TransactionViewSet(
     lookup_field = "uuid"
     serializer_class = TransactionSerializer
     pagination_class = TransactionListPaginator
-    filter_backends = [filters.SearchFilter]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
 
     # fields that are queried for search
     search_fields = ['lms_user_email', 'content_title']
+
+    # Settings that control list ordering, powered by OrderingFilter.
+    # Fields in `ordering_fields` are what we allow to be passed to the "?ordering=" query param.
+    ordering_fields = ['created', 'quantity']
+    # `ordering` defines the default order.
+    ordering = ['-created']
 
     # Fields that control permissions for 'list' actions, required by PermissionRequiredForListingMixin.
     list_lookup_field = "ledger__subsidy__enterprise_customer_uuid"

--- a/enterprise_subsidy/apps/api/v2/views/transaction.py
+++ b/enterprise_subsidy/apps/api/v2/views/transaction.py
@@ -83,11 +83,17 @@ class TransactionAdminListCreate(TransactionBaseViewMixin, generics.ListCreateAP
     of the related subsidy's enterprise customer.  It lists all transactions
     for the requested subsidy, or a subset thereof, depending on the query parameters.
     """
-    filter_backends = [drf_filters.DjangoFilterBackend, filters.SearchFilter]
+    filter_backends = [drf_filters.DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     filterset_class = TransactionAdminFilterSet
 
     # fields that are queried for search
     search_fields = ['lms_user_email', 'content_title']
+
+    # Settings that control list ordering, powered by OrderingFilter.
+    # Fields in `ordering_fields` are what we allow to be passed to the "?ordering=" query param.
+    ordering_fields = ['created', 'quantity']
+    # `ordering` defines the default order.
+    ordering = ['-created']
 
     def __init__(self, *args, **kwargs):
         self.extra_context = {}


### PR DESCRIPTION
### Description

- adds an `ordering` query param which supports `created` and `quantity`
- https://2u-internal.atlassian.net/browse/ENT-7952

