### PR TITLE
fix: Adds CSRF trusted origin to devstack settings

### DIFF
--- a/enterprise_subsidy/settings/devstack.py
+++ b/enterprise_subsidy/settings/devstack.py
@@ -6,6 +6,12 @@ CORS_ORIGIN_WHITELIST = (
     'http://localhost:1991',  # frontend-app-admin-portal
 )
 
+CSRF_TRUSTED_ORIGINS = [
+    'http://localhost:18450',
+    'http://localhost:8734',
+    'http://localhost:1991',
+]
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',


### PR DESCRIPTION
### Description
Adds CSRF_TRUSTED_ORIGIN to the devstack setting to overcome a local development issue that appeared in the support tools repository when provisioning new subsidies/policies.
![image](https://github.com/openedx/enterprise-subsidy/assets/82611798/cf787c1d-c633-458f-889f-66392f0660d6)

Preemptively added the learner portal and admin portal local development endpoints to have the trusted origins list match the whitelist. 

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
