### PR TITLE
feat: adhering transaction api list view to edx rest framework default pagination

### DIFF
--- a/enterprise_subsidy/apps/api/paginators.py
+++ b/enterprise_subsidy/apps/api/paginators.py
@@ -3,12 +3,13 @@ Customer paginators for the subsidy API.
 """
 from math import ceil
 
+from edx_rest_framework_extensions.paginators import DefaultPagination
 from rest_framework import pagination
 
 from ..subsidy.models import Subsidy
 
 
-class TransactionListPaginator(pagination.PageNumberPagination):
+class TransactionListPaginator(DefaultPagination):
     """
     Optionally adds an `aggregates` dictionary to the base pagination response
     of transaction list views.

--- a/enterprise_subsidy/apps/api/v2/tests/test_transaction_views.py
+++ b/enterprise_subsidy/apps/api/v2/tests/test_transaction_views.py
@@ -380,6 +380,20 @@ class TransactionAdminListViewTests(APITestBase):
         self._prepend_initial_transaction_uuid(subsidy_uuid, expected_response_uuids)
         self.assertEqual(sorted(response_uuids), sorted(expected_response_uuids))
 
+    def test_admin_list_transactions_default_pagination_behavior(self):
+        """
+        Test listing of Transaction records for an admin or operator adheres to edx rest framework default pagination.
+        """
+        self.set_up_operator()
+        subsidy_uuid = APITestBase.subsidy_3_uuid
+        url = reverse("api:v2:transaction-admin-list-create", args=[subsidy_uuid])
+
+        response = self.client.get(url)
+        assert "num_pages" in response.data.keys()
+        assert "count" in response.data.keys()
+        assert "current_page" in response.data.keys()
+        assert "results" in response.data.keys()
+
     @ddt.data('admin', 'operator')
     def test_admin_list_transactions_happy_path_with_filters(self, role):
         """


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8106

### Description
Ensure the enterprise-subsidy transactions list API utilizes the DefaultPagination class from edx-drf-extensions.

### Testing instructions

Unit tests

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
