### PR TITLE
feat: adding a non-customer dependent content metadata api client

### DIFF
--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -22,6 +22,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from enterprise_subsidy.apps.api.v1.tests.mixins import STATIC_ENTERPRISE_UUID, STATIC_LMS_USER_ID, APITestMixin
+from enterprise_subsidy.apps.api_client.enterprise_catalog import EnterpriseCatalogApiClient
 from enterprise_subsidy.apps.subsidy.constants import SYSTEM_ENTERPRISE_ADMIN_ROLE, SYSTEM_ENTERPRISE_LEARNER_ROLE
 from enterprise_subsidy.apps.subsidy.models import RevenueCategoryChoices, Subsidy
 from enterprise_subsidy.apps.subsidy.tests.factories import SubsidyFactory
@@ -1654,8 +1655,10 @@ class ContentMetadataViewSetTests(APITestBase):
             # Validate that, in the first, non-cached request, we call
             # the enterprise catalog endpoint via the client, and that
             # a `skip_customer_fetch` parameter is included in the request.
+            catalog_customer_base = EnterpriseCatalogApiClient().enterprise_customer_endpoint
+            expected_request_url = f"{catalog_customer_base}{customer_uuid}/content-metadata/{expected_content_key}/"
             mock_oauth_client.return_value.get.assert_called_once_with(
-                f'api/v1/enterprise-customer/{customer_uuid}/content-metadata/{expected_content_key}/',
+                expected_request_url,
                 params={
                     'skip_customer_fetch': True,
                 },
@@ -1711,8 +1714,10 @@ class ContentMetadataViewSetTests(APITestBase):
 
             assert response.status_code == catalog_status_code
             assert response.json() == expected_response
+            catalog_customer_endpoint = EnterpriseCatalogApiClient().enterprise_customer_endpoint
+            expected_request_url = f"{catalog_customer_endpoint}{customer_uuid}/content-metadata/content_key/"
             mock_oauth_client.return_value.get.assert_called_once_with(
-                f'api/v1/enterprise-customer/{customer_uuid}/content-metadata/content_key/',
+                expected_request_url,
                 params={
                     'skip_customer_fetch': True,
                 },

--- a/enterprise_subsidy/apps/api_client/tests/test_enterprise_catalog.py
+++ b/enterprise_subsidy/apps/api_client/tests/test_enterprise_catalog.py
@@ -83,10 +83,10 @@ class EnterpriseCatalogApiClientTests(TestCase):
         }
 
     @mock.patch('enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient', return_value=mock.MagicMock())
-    def test_successful_fetch_course_content_metadata(self, mock_oauth_client):
+    def test_successful_fetch_course_content_metadata_for_customer(self, mock_oauth_client):
         """
-        Test the enterprise catalog client's ability to handle api requests to fetch content metadata from the catalog
-        service.
+        Test the enterprise catalog client's ability to handle api requests to fetch customer specific content metadata
+        from the catalog service.
         """
         mock_oauth_client.return_value.get.return_value = MockResponse(self.course_metadata, 200)
         enterprise_catalog_client = EnterpriseCatalogApiClient()
@@ -94,3 +94,16 @@ class EnterpriseCatalogApiClientTests(TestCase):
             self.enterprise_customer_uuid, self.course_key
         )
         assert response == self.course_metadata
+
+    @mock.patch('enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient', return_value=mock.MagicMock())
+    def test_successful_fetch_course_content_metadata(self, mock_oauth_client):
+        """
+        Test the enterprise catalog client's ability to handle api requests to fetch content metadata from the catalog
+        service.
+        """
+        mock_oauth_client.return_value.get.return_value = MockResponse(self.course_metadata, 200)
+        enterprise_catalog_client = EnterpriseCatalogApiClient()
+        response = enterprise_catalog_client.get_content_metadata(self.course_key)
+        assert response == self.course_metadata
+        assert mock_oauth_client.return_value.get.call_args.args[0] == enterprise_catalog_client.metadata_endpoint
+        assert mock_oauth_client.return_value.get.call_args.kwargs == {'params': {'content_identifiers': ['edX+DemoX']}}

--- a/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py
+++ b/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py
@@ -16,7 +16,6 @@ from enterprise_subsidy.apps.api_client.enterprise import EnterpriseApiClient
 from enterprise_subsidy.apps.content_metadata.api import ContentMetadataApi
 from enterprise_subsidy.apps.fulfillment.api import GEAGFulfillmentHandler
 from enterprise_subsidy.apps.fulfillment.exceptions import FulfillmentException
-from enterprise_subsidy.apps.subsidy.models import Subsidy
 from enterprise_subsidy.apps.transaction.utils import generate_transaction_reversal_idempotency_key
 
 logger = logging.getLogger(__name__)
@@ -178,17 +177,7 @@ class Command(BaseCommand):
 
         # Memoize the content metadata for the course run fetched from the enterprise catalog
         if not self.fetched_content_metadata.get(enrollment_course_run_key):
-            try:
-                customer_uuid = related_transaction.ledger.subsidy.enterprise_customer_uuid
-            except Subsidy.DoesNotExist:
-                logger.warning(
-                    f"{self.dry_run_prefix}Unable to determine enterprise customer uuid for transaction: "
-                    f"{related_transaction}"
-                )
-                return 0
-
             content_metadata = ContentMetadataApi.get_content_metadata(
-                customer_uuid,
                 enrollment_course_run_key,
             )
             self.fetched_content_metadata[enrollment_course_run_key] = content_metadata

--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -23,9 +23,9 @@ def root(*path_fragments):
 
 
 LMS_URL = os.environ.get('LMS_URL', 'localhost:18000')
-ENTERPRISE_CATALOG_URL = os.environ.get('ENTERPRISE_CATALOG_URL', 'localhost:18160')
-ENTERPRISE_SUBSIDY_URL = os.environ.get('ENTERPRISE_SUBSIDY_URL', 'localhost:18280')
-FRONTEND_APP_LEARNING_URL = os.environ.get('FRONTEND_APP_LEARNING_URL', 'localhost:2000')
+ENTERPRISE_CATALOG_URL = os.environ.get('ENTERPRISE_CATALOG_URL', 'https://localhost:18160')
+ENTERPRISE_SUBSIDY_URL = os.environ.get('ENTERPRISE_SUBSIDY_URL', 'https://localhost:18280')
+FRONTEND_APP_LEARNING_URL = os.environ.get('FRONTEND_APP_LEARNING_URL', 'https://localhost:2000')
 
 BULK_ENROLL_REQUEST_TIMEOUT_SECONDS = os.environ.get('BULK_ENROLL_REQUEST_TIMEOUT_SECONDS', 20)
 


### PR DESCRIPTION
### Description
Right now all of our enterprise catalog content metadata API client methods are depending on customer because the catalog service only surfaced content through a customer's context. This was too rigid for our purposes in the transaction reversal procedure where we needed to query for the course start date regardless of whether or not the content belonged under the customer's catalog. I've updated the catalog service to surface content metadata records without tying the serializer to the customer, so that the subsidy service can query and find the information it needs without having the association between content and customer catalog.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
