### PR TITLE
feat: some transaction, subsidy, and ledger django admin improvements

### DIFF
--- a/enterprise_subsidy/apps/subsidy/admin.py
+++ b/enterprise_subsidy/apps/subsidy/admin.py
@@ -38,6 +38,8 @@ class SubsidyAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
         model = Subsidy
         fields = '__all__'
 
+    djangoql_completion_enabled_by_default = False
+
     _all_fields = [field.name for field in Subsidy._meta.get_fields()]
 
     if can_modify():


### PR DESCRIPTION
### Description
* DjangoQL off by default in Subsidy, Ledger, and Transaction

## Ledger admin changes
* Add an inline to the related subsidy.

## Transaction admin changes
* EC uuid and ledger uuid in the list display
* Searchable by ledger and EC uuids.
* Add EC uuid to edit view

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
