### PR TITLE
build: make pip_requirements a prereq for production-requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ validation_requirements: pip_requirements ## sync to requirements for testing & 
 doc_requirements:
 	pip-sync -q requirements/doc.txt
 
-production-requirements: ## install requirements for production
+production-requirements: pip_requirements ## install requirements for production
 	pip-sync -q requirements/production.txt
 
 static: ## generate static files


### PR DESCRIPTION
### Description

When trying to deploy enterprise-subsidy using a Ansible playbook based on the edx_django_service role - https://github.com/openedx/configuration/pull/7107, the production requirements fail to install as the pip-tools are missing. This commit makes installing pip-tools a prereq for install production-requirements.


### Testing instructions

Running `make production-requirements` after a fresh clone completes without fail.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
