### PR TITLE
fix: accounting for content type of metadata when writing transaction reversals

### DIFF
--- a/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py
+++ b/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py
@@ -82,10 +82,13 @@ class Command(BaseCommand):
         enrollment_course_run_key = enterprise_course_enrollment.get("course_id")
         enrollment_created_at = enterprise_course_enrollment.get("created")
         course_start_date = None
-        for run in content_metadata.get('course_runs'):
-            if run.get('key') == enrollment_course_run_key:
-                course_start_date = run.get('start')
-                break
+        if content_metadata.get('content_type') == 'courserun':
+            course_start_date = content_metadata.get('start')
+        else:
+            for run in content_metadata.get('course_runs', []):
+                if run.get('key') == enrollment_course_run_key:
+                    course_start_date = run.get('start')
+                    break
 
         if not course_start_date:
             logger.warning(


### PR DESCRIPTION
If the subsidy service requests non customer specific content metadata for a course run, it will only get metadata on that course run (not the parent course). This adds the flexibility to not assume the content metadata is of content_type course 

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
