### PR TITLE
fix: pulling results out of the response payload from the catalog service for content metadata

### DIFF
--- a/enterprise_subsidy/apps/api_client/enterprise_catalog.py
+++ b/enterprise_subsidy/apps/api_client/enterprise_catalog.py
@@ -44,7 +44,8 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
         try:
             response = self.client.get(content_metadata_url, params=query_params)
             response.raise_for_status()
-            return response.json()
+            response_json = response.json()
+            return response_json['results'][0] if response_json['results'] else None
         except requests.exceptions.HTTPError as exc:
             if hasattr(response, 'text'):
                 logger.exception(

--- a/enterprise_subsidy/apps/api_client/tests/test_enterprise_catalog.py
+++ b/enterprise_subsidy/apps/api_client/tests/test_enterprise_catalog.py
@@ -101,7 +101,15 @@ class EnterpriseCatalogApiClientTests(TestCase):
         Test the enterprise catalog client's ability to handle api requests to fetch content metadata from the catalog
         service.
         """
-        mock_oauth_client.return_value.get.return_value = MockResponse(self.course_metadata, 200)
+        mock_oauth_client.return_value.get.return_value = MockResponse(
+            {
+                'results': [self.course_metadata],
+                'count': 1,
+                'next': None,
+                'previous': None,
+            },
+            200,
+        )
         enterprise_catalog_client = EnterpriseCatalogApiClient()
         response = enterprise_catalog_client.get_content_metadata(self.course_key)
         assert response == self.course_metadata


### PR DESCRIPTION

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
