### PR TITLE
fix: correct variant is included in summary data for content

### DIFF
--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -1551,9 +1551,14 @@ class ContentMetadataViewSetTests(APITestBase):
             "slug": "2u",
             "description": "2U, Trilogy, Getsmarter -- external source for 2u courses and programs"
         },
-        "additional_metadata": {
-            "variant_id": "79a95406-a9ac-49b3-a27c-44f3fd06092e"
-        }
+        "course_runs": [
+            {
+                "key": course_run_key,
+                "uuid": course_run_uuid,
+                "variant_id": "79a95406-a9ac-49b3-a27c-44f3fd06092e",
+            }
+        ],
+        "advertised_course_run_uuid": course_run_uuid,
     }
     mock_http_error_reason = 'Something Went Wrong'
     mock_http_error_url = 'foobar.com'
@@ -1587,8 +1592,8 @@ class ContentMetadataViewSetTests(APITestBase):
             'expected_content_title': content_title,
             'expected_content_uuid': content_uuid_2,
             'expected_content_key': content_key_2,
-            'expected_course_run_uuid': None,
-            'expected_course_run_key': None,
+            'expected_course_run_uuid': str(course_run_uuid),
+            'expected_course_run_key': course_run_key,
             'expected_content_price': 59949,
             'mock_metadata': executive_education_course_metadata,
             'expected_source': '2u',

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -97,14 +97,24 @@ class ContentMetadataApi:
                 return source_name
         return ProductSources.EDX.value
 
-    def get_geag_variant_id_for_content(self, content_data):
+    def get_geag_variant_id_for_content(self, content_identifier, content_data):
         """
-        Returns the GEAG ``variant_id`` or ``None``, given a dict of ``content_data``.
-        In the GEAG system a ``variant_id`` is aka a ``product_id``.
+        Get a GEAG ``variant_id`` for the given content.
+
+        Args:
+            content_identifier (str): The content for which to get a variant.
+            content_data (dict): The content metadata dict fetched from the enterprise-catalog API.
+
+        Returns:
+            bool: The ``variant_id`` if one is found, or None otherwise.
+
+        Notes:
+            * In the GEAG system a ``variant_id`` is aka a ``product_id``.
+            * The ``content_identifier`` may be a course run key, in which case the variant returned will correspond to
+              that specific run, instead of the advertised run.
         """
-        variant_id = None
-        if additional_metadata := content_data.get('additional_metadata'):
-            variant_id = additional_metadata.get('variant_id')
+        course_run_content = self.get_course_run(content_identifier, content_data)
+        variant_id = course_run_content.get('variant_id')
         return variant_id
 
     def summary_data_for_content(self, content_identifier, content_data):
@@ -122,7 +132,7 @@ class ContentMetadataApi:
             'source': self.product_source_for_content(content_data),
             'mode': self.mode_for_content(content_data),
             'content_price': self.price_for_content(content_data, course_run_content),
-            'geag_variant_id': self.get_geag_variant_id_for_content(content_data),
+            'geag_variant_id': self.get_geag_variant_id_for_content(content_identifier, content_data),
         }
 
     def get_course_run(self, content_identifier, content_data):


### PR DESCRIPTION
**Background**: There's an internal helper method to generate "summary" data for a piece of content, which is used all over this codebase to extract relevant bits of metadata from said content. The summary data is also used verbatim in the enterprise-subsidy content metadata API endpoint (`/api/v1/content-metadata/<content-identifier>/`). The problem was that this helper method relied on `additional_metadata` from the content metadata, but that dict is now deprecated.  Furthermore, when a course RUN key was passed to this helper method, the result would incorrectly include the variant_id of the advertised run, potentially a different run than request.

**This PR**: Change logic to actually fetch the `variant_id` of the requested course run, and fallback to that of the advertised course run.  Furthermore, it cuts `additional_metadata` out of the loop entirely.

ENT-8520