### PR TITLE
feat: adding api subsidy endpoint to surface aggregated subsidy enrollment data

### DIFF
--- a/enterprise_subsidy/apps/api/schema.py
+++ b/enterprise_subsidy/apps/api/schema.py
@@ -42,6 +42,16 @@ class Parameters:
             "The UUID associated with the requesting user's enterprise customer."
         ),
     )
+    ENTERPRISE_SUBSIDY_ACCESS_POLICY_UUID = OpenApiParameter(
+        'subsidy_access_policy_uuid',
+        type=OpenApiTypes.UUID,
+        location=OpenApiParameter.QUERY,
+        required=False,
+        allow_blank=True,
+        description=(
+            "The UUID associated with the subsidy access policy to which the query pertains."
+        ),
+    )
 
 
 def _open_api_error_response(exception_class, detail_str, example_name):

--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -307,6 +307,30 @@ class TransactionCreationRequestSerializer(serializers.ModelSerializer):
 
 
 # pylint: disable=abstract-method
+class SubsidyLearnerAggregateSerializer(serializers.Serializer):
+    """
+    Serializer for providing responses to queries about aggregate enrollment data for a particular subsidy
+    """
+    lms_user_id = serializers.IntegerField(
+        help_text='User ID associated with user tied to a subsidy\'s transaction.'
+    )
+    total = serializers.IntegerField(
+        help_text='Number of enrollments found for the user.'
+    )
+
+
+# pylint: disable=abstract-method
+class SubsidyLearnerAggregateRequestSerializer(serializers.Serializer):
+    """
+    Serializer for creating a subsidy request
+    """
+    subsidy_access_policy_uuid = serializers.UUIDField(
+        required=False,
+        help_text="UUID of the enterprise subsidy policy. Used to filter down aggregate subsidy enrollment data",
+    )
+
+
+# pylint: disable=abstract-method
 class CanRedeemResponseSerializer(serializers.Serializer):
     """
     Serializer for providing responses to queries about redeemability

--- a/enterprise_subsidy/apps/api/v1/urls.py
+++ b/enterprise_subsidy/apps/api/v1/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
         ContentMetadataViewSet.as_view(),
         name='content-metadata'
     ),
+    path(
+        'subsidies/<uuid>/aggregates-by-learner',
+        SubsidyViewSet.as_view({'get': 'get_aggregates_by_learner'}),
+        name='subsidies-aggregates-by-learner'
+    ),
 ]
 
 urlpatterns += router.urls

--- a/enterprise_subsidy/apps/api/v1/views/content_metadata.py
+++ b/enterprise_subsidy/apps/api/v1/views/content_metadata.py
@@ -41,7 +41,7 @@ class ContentMetadataViewSet(
     GenericAPIView
 ):
     """
-    Subsidy service viewset partaining to content metadata.
+    Subsidy service viewset pertaining to content metadata.
 
     GET /api/v1/content-metadata/{Content Identifier}/
 


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8562

first of two steps. First expose aggregated enrollment data pertaining to particular subsidies from enterprise-subsidy via a new API endpoint. Then have access query and cache said new endpoint, requesting pages of enterprise group member data and zipping the data together to form a hydrated enterprise group members view.

### Testing instructions

run unit tests, alternatively hit `http://localhost:18280/api/v1/subsidies/<subsidy-UUID>/aggregated-enrollments` after fetching and running locally

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
