### PR TITLE
build: do not tag this in the named open edx release

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -13,9 +13,3 @@ oeps:
     oep-18: true
     oep-30:
         state: true
-openedx-release:
-    # The openedx-release key is described in OEP-10:
-    #   https://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
-    # The FAQ might also be helpful: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1331268879/Open+edX+Release+FAQ
-    maybe: true   # Delete this "maybe" line when you have decided about Open edX inclusion.
-    ref: main


### PR DESCRIPTION
This repo has been "maybe" for a while, but it has not been tagged yet. I propose that we remove the "maybe" and simply do not tag it. My reasoning is that it is not clear from the README or the ADRs how this microservice could be used by an Open edX site operator.

According to [OEP-10](https://docs.openedx.org/projects/openedx-proposals/en/latest/processes/oep-0010-proc-openedx-releases.html#levels-of-support): 
> To be included in an Open edX release, a component must meet these criteria.
> * It must be successfully merged into its repository’s release-from branch. This is typically master, though it can be any branch.
> * It must be installable in at least one of the supported installation methods.
> * It must be usable in the installed configuration.

This decision can always be reversed in the future by adding a release branch to catalog-info.yaml