### PR TITLE
feat: emit transaction lifecycle events

### DIFF
--- a/enterprise_subsidy/apps/core/event_bus.py
+++ b/enterprise_subsidy/apps/core/event_bus.py
@@ -1,0 +1,91 @@
+"""
+Functions for serializing and emiting Open edX event bus signals.
+"""
+from openedx_events.enterprise.data import LedgerTransaction, LedgerTransactionReversal
+from openedx_events.enterprise.signals import (
+    LEDGER_TRANSACTION_COMMITTED,
+    LEDGER_TRANSACTION_CREATED,
+    LEDGER_TRANSACTION_FAILED,
+    LEDGER_TRANSACTION_REVERSED
+)
+
+
+def serialize_transaction(transaction_record):
+    """
+    Serializes the ``transaction_record``into a defined set of attributes
+    for use in the event-bus signal.
+    """
+    reversal_data = None
+    if reversal_record := transaction_record.get_reversal():
+        reversal_data = LedgerTransactionReversal(
+            uuid=reversal_record.uuid,
+            created=reversal_record.created,
+            modified=reversal_record.modified,
+            idempotency_key=reversal_record.idempotency_key,
+            quantity=reversal_record.quantity,
+            state=reversal_record.state,
+        )
+    data = LedgerTransaction(
+        uuid=transaction_record.uuid,
+        created=transaction_record.created,
+        modified=transaction_record.modified,
+        idempotency_key=transaction_record.idempotency_key,
+        quantity=transaction_record.quantity,
+        state=transaction_record.state,
+        ledger_uuid=transaction_record.ledger.uuid,
+        subsidy_access_policy_uuid=transaction_record.subsidy_access_policy_uuid,
+        lms_user_id=transaction_record.lms_user_id,
+        content_key=transaction_record.content_key,
+        parent_content_key=transaction_record.parent_content_key,
+        fulfillment_identifier=transaction_record.fulfillment_identifier,
+        reversal=reversal_data,
+    )
+    return data
+
+
+def send_transaction_created_event(transaction_record):
+    """
+    Sends the LEDGER_TRANSACTION_CREATED open edx event for the given ``transaction_record``.
+
+    Parameters:
+      transaction_record (openedx_ledger.models.Transaction): A transaction record.
+    """
+    LEDGER_TRANSACTION_CREATED.send_event(
+        ledger_transaction=serialize_transaction(transaction_record),
+    )
+
+
+def send_transaction_committed_event(transaction_record):
+    """
+    Sends the LEDGER_TRANSACTION_COMMITTED open edx event for the given ``transaction_record``.
+
+    Parameters:
+      transaction_record (openedx_ledger.models.Transaction): A transaction record.
+    """
+    LEDGER_TRANSACTION_COMMITTED.send_event(
+        ledger_transaction=serialize_transaction(transaction_record),
+    )
+
+
+def send_transaction_failed_event(transaction_record):
+    """
+    Sends the LEDGER_TRANSACTION_FAILED open edx event for the given ``transaction_record``.
+
+    Parameters:
+      transaction_record (openedx_ledger.models.Transaction): A transaction record.
+    """
+    LEDGER_TRANSACTION_FAILED.send_event(
+        ledger_transaction=serialize_transaction(transaction_record),
+    )
+
+
+def send_transaction_reversed_event(transaction_record):
+    """
+    Sends the LEDGER_TRANSACTION_REVERSED open edx event for the given ``transaction_record``.
+
+    Parameters:
+      transaction_record (openedx_ledger.models.Transaction): A transaction record.
+    """
+    LEDGER_TRANSACTION_REVERSED.send_event(
+        ledger_transaction=serialize_transaction(transaction_record),
+    )

--- a/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py
+++ b/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py
@@ -199,9 +199,16 @@ class Command(BaseCommand):
         )
 
         if not self.dry_run:
-            cancel_transaction_external_fulfillment(related_transaction)
-            reverse_transaction(related_transaction, unenroll_time=enrollment_unenrolled_at)
-            return 1
+            successfully_canceled = cancel_transaction_external_fulfillment(related_transaction)
+            if successfully_canceled:
+                reverse_transaction(related_transaction, unenroll_time=enrollment_unenrolled_at)
+                return 1
+            else:
+                logger.warning(
+                    'Could not cancel external fulfillment for transaction %s, no reversal written',
+                    related_transaction.uuid,
+                )
+                return 0
         else:
             logger.info(
                 f"{self.dry_run_prefix}Would have written Reversal record for enterprise fulfillment: "

--- a/enterprise_subsidy/apps/transaction/signals/handlers.py
+++ b/enterprise_subsidy/apps/transaction/signals/handlers.py
@@ -6,6 +6,8 @@ import logging
 from django.dispatch import receiver
 from openedx_ledger.signals.signals import TRANSACTION_REVERSED
 
+from enterprise_subsidy.apps.core.event_bus import send_transaction_reversed_event
+
 from ..api import cancel_transaction_external_fulfillment, cancel_transaction_fulfillment
 from ..exceptions import TransactionFulfillmentCancelationException
 
@@ -29,6 +31,7 @@ def listen_for_transaction_reversal(sender, **kwargs):
     try:
         cancel_transaction_external_fulfillment(transaction)
         cancel_transaction_fulfillment(transaction)
+        send_transaction_reversed_event(transaction)
     except TransactionFulfillmentCancelationException as exc:
         error_msg = f"Error canceling platform fulfillment {transaction.fulfillment_identifier}: {exc}"
         logger.exception(error_msg)

--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -377,3 +377,47 @@ LMS_USER_DATA_CACHE_TIMEOUT = ONE_HOUR
 # be more drift between the time of allocation and the time of redemption.
 ALLOCATION_PRICE_VALIDATION_LOWER_BOUND_RATIO = .80
 ALLOCATION_PRICE_VALIDATION_UPPER_BOUND_RATIO = 1.20
+
+# Kafka and event broker settings
+TRANSACTION_LIFECYCLE_TOPIC = "enterprise-subsidy-ledger-transaction-lifecycle"
+TRANSACTION_CREATED_EVENT_NAME = "org.openedx.enterprise.subsidy_ledger_transaction.created.v1"
+TRANSACTION_COMMITTED_EVENT_NAME = "org.openedx.enterprise.subsidy_ledger_transaction.committed.v1"
+TRANSACTION_FAILED_EVENT_NAME = "org.openedx.enterprise.subsidy_ledger_transaction.failed.v1"
+TRANSACTION_REVERSED_EVENT_NAME = "org.openedx.enterprise.subsidy_ledger_transaction.reversed.v1"
+
+# .. setting_name: EVENT_BUS_PRODUCER_CONFIG
+# .. setting_default: all events disabled
+# .. setting_description: Dictionary of event_types mapped to dictionaries of topic to topic-related configuration.
+#    Each topic configuration dictionary contains
+#    * `enabled`: a toggle denoting whether the event will be published to the topic. These should be annotated
+#       according to
+#       https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html
+#    * `event_key_field` which is a period-delimited string path to event data field to use as event key.
+#    Note: The topic names should not include environment prefix as it will be dynamically added based on
+#    EVENT_BUS_TOPIC_PREFIX setting.
+EVENT_BUS_PRODUCER_CONFIG = {
+    TRANSACTION_CREATED_EVENT_NAME: {
+        TRANSACTION_LIFECYCLE_TOPIC: {
+            'event_key_field': 'ledger_transaction.uuid',
+            'enabled': False,
+        },
+    },
+    TRANSACTION_COMMITTED_EVENT_NAME: {
+        TRANSACTION_LIFECYCLE_TOPIC: {
+            'event_key_field': 'ledger_transaction.uuid',
+            'enabled': False,
+        },
+    },
+    TRANSACTION_FAILED_EVENT_NAME: {
+        TRANSACTION_LIFECYCLE_TOPIC: {
+            'event_key_field': 'ledger_transaction.uuid',
+            'enabled': False,
+        },
+    },
+    TRANSACTION_REVERSED_EVENT_NAME: {
+        TRANSACTION_LIFECYCLE_TOPIC: {
+            'event_key_field': 'ledger_transaction.uuid',
+            'enabled': False,
+        },
+    },
+}

--- a/enterprise_subsidy/settings/devstack.py
+++ b/enterprise_subsidy/settings/devstack.py
@@ -90,4 +90,14 @@ EVENT_BUS_PRODUCER = 'edx_event_bus_kafka.create_producer'
 EVENT_BUS_CONSUMER = 'edx_event_bus_kafka.KafkaEventConsumer'
 EVENT_BUS_TOPIC_PREFIX = 'dev'
 
-# Application settings go here...
+EVENT_BUS_PRODUCER_CONFIG[TRANSACTION_CREATED_EVENT_NAME][TRANSACTION_LIFECYCLE_TOPIC]['enabled'] = True
+EVENT_BUS_PRODUCER_CONFIG[TRANSACTION_COMMITTED_EVENT_NAME][TRANSACTION_LIFECYCLE_TOPIC]['enabled'] = True
+EVENT_BUS_PRODUCER_CONFIG[TRANSACTION_FAILED_EVENT_NAME][TRANSACTION_LIFECYCLE_TOPIC]['enabled'] = True
+EVENT_BUS_PRODUCER_CONFIG[TRANSACTION_REVERSED_EVENT_NAME][TRANSACTION_LIFECYCLE_TOPIC]['enabled'] = True
+
+# Private settings
+# The local.py settings file also does this, but then this current file (devstack.py)
+# imports *from* local.py, so anything earlier in this file overrides what's in private.py
+# We want private.py to have the highest precedence, so re-import private settings again here.
+if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+    from .private import *  # pylint: disable=import-error

--- a/enterprise_subsidy/settings/test.py
+++ b/enterprise_subsidy/settings/test.py
@@ -22,3 +22,16 @@ GET_SMARTER_API_URL = 'http://getsmarter.com/enterprise/allocate'
 GET_SMARTER_OAUTH2_KEY = 'get-smarter-key'
 GET_SMARTER_OAUTH2_SECRET = 'get-smarter-secret'
 GET_SMARTER_OAUTH2_PROVIDER_URL = 'https://get-smarter.provider.url'
+
+# Kafka Settings
+# We set to fake server addresses because we shouldn't actually be emitting real events during tests
+EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = 'http://test.schema-registry:8000'
+EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS = 'test.kafka:8001'
+EVENT_BUS_PRODUCER = 'edx_event_bus_kafka.create_producer'
+EVENT_BUS_CONSUMER = 'edx_event_bus_kafka.KafkaEventConsumer'
+EVENT_BUS_TOPIC_PREFIX = 'dev-test'
+
+EVENT_BUS_PRODUCER_CONFIG[TRANSACTION_CREATED_EVENT_NAME][TRANSACTION_LIFECYCLE_TOPIC]['enabled'] = True
+EVENT_BUS_PRODUCER_CONFIG[TRANSACTION_COMMITTED_EVENT_NAME][TRANSACTION_LIFECYCLE_TOPIC]['enabled'] = True
+EVENT_BUS_PRODUCER_CONFIG[TRANSACTION_FAILED_EVENT_NAME][TRANSACTION_LIFECYCLE_TOPIC]['enabled'] = True
+EVENT_BUS_PRODUCER_CONFIG[TRANSACTION_REVERSED_EVENT_NAME][TRANSACTION_LIFECYCLE_TOPIC]['enabled'] = True

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -22,7 +22,7 @@ edx-rbac
 edx-rest-api-client
 jsonfield2
 mysqlclient
-openedx-events
+# openedx-events
 openedx-ledger
 pymemcache
 pytz
@@ -30,3 +30,6 @@ rules
 getsmarter-api-clients
 django-log-request-id
 django-clearcache
+
+# Temporary pin to a fork to use new enterprise events
+git+https://github.com/iloveagent57/openedx-events.git@67d7bc392af88996ca1e63d789c6017248dac305


### PR DESCRIPTION
Emit openedx events (to the event bus) when transactions are created, committed, failed, and reversed.
Additionally fixes a bug in the write-reversals mgmt command that proceeded to write a reversal in case an external fulfillment could not successfully be canceled.
ENT-8761
ENT-9009

See proposed consumption: https://github.com/openedx/enterprise-access/pull/502

### Testing instructions
0. Run `make app-logs` in enterprise-subsidy, or have the local kafka control center running in your browser.
1. Find a combination of (policy, learner, content key) that can be redeemed.
2. Hit the policy redeem endpoint.
3. The response should be a committed transaction, and you should see events emitted to kafka in your logs.

### Example of reversal signal being sent
From enterprise-subsidy:
```
enterprise-subsidy.app  | 2024-06-26 14:02:32,049 DEBUG 129 [urllib3.connectionpool] [user 6] [ip 172.18.0.1] [request_id None] connectionpool.py:546 - http://edx.devstack.schema-registry:8081 "POST /subjects/dev-enterprise-subsidy-ledger-transaction-lifecycle-org.openedx.enterprise.subsidy_ledger_transaction.reversed.v1.CloudEvent/versions?normalize=False HTTP/11" 200 8
...
enterprise-subsidy.app  | 2024-06-26 14:02:32,579 INFO 129 [edx_event_bus_kafka.internal.producer] [user None] [ip None] [request_id None] producer.py:244 - Message delivered to Kafka event bus: topic=dev-enterprise-subsidy-ledger-transaction-lifecycle, partition=0, offset=2, message_id=bb410e7a-33c4-11ef-a3f9-0242ac120013, key=b'\x00\x00\x00\x00\x01H3eacfe31-2453-4b2f-8ba5-392214dd8a98'
```

In local confluent:
![image](https://github.com/openedx/enterprise-subsidy/assets/2307986/68829626-7595-4bda-9f56-c91e83408299)

The event data:
```
{
  "ledger_transaction": {
    "uuid": "3eacfe31-2453-4b2f-8ba5-392214dd8a98",
    "created": "2024-06-26T14:01:38.537264+00:00",
    "modified": "2024-06-26T14:01:39.489644+00:00",
    "idempotency_key": "ledger-for-subsidy-4c53f616-5ea0-42a0-9430-ba165cb2c916-ed691d7727be279ea98a40ff8517a219",
    "quantity": -14800,
    "state": "committed",
    "ledger_uuid": "2cc1f351-ee20-4c0f-92e8-55e6e442d22a",
    "subsidy_access_policy_uuid": "3cc0ad2c-ede1-476c-8271-97683855e41d",
    "lms_user_id": 2,
    "content_key": "course-v1:edX+DemoX+Demo_Course",
    "parent_content_key": {
      "string": "course-v1:edX+DemoX+Demo_Course"
    },
    "fulfillment_identifier": {
      "string": "1ab9b0ee-bcb2-4798-8d42-fd4176cb68e8"
    },
    "reversal": {
      "org.openedx.enterprise.subsidy_ledger_transaction.reversed.v1.LedgerTransactionReversal": {
        "uuid": "076e3be2-a702-4400-b3cf-27b1c077e740",
        "created": "2024-06-26T14:02:27.874315+00:00",
        "modified": "2024-06-26T14:02:27.874315+00:00",
        "idempotency_key": "admin-invoked-reverse-3eacfe31-2453-4b2f-8ba5-392214dd8a98",
        "quantity": 14800,
        "state": "committed"
      }
    }
  }
}
```

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
