### PR TITLE
feat: Create and serialize total_deposits field

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for the enterprise-subsidy API.
 """
+import json
 from logging import getLogger
 from urllib.parse import urljoin
 
@@ -28,6 +29,7 @@ class SubsidySerializer(serializers.ModelSerializer):
     """
     current_balance = serializers.SerializerMethodField(help_text="The current (remaining) balance of this subsidy.")
     is_active = serializers.BooleanField(read_only=True, help_text="Whether this subsidy is currently active.")
+    total_deposits = serializers.SerializerMethodField(help_text="The aggregate of the initial balance plus all adjustments made on the subsidy in usd cents")
 
     class Meta:
         """
@@ -48,6 +50,7 @@ class SubsidySerializer(serializers.ModelSerializer):
             "internal_only",
             "revenue_category",
             "is_active",
+            "total_deposits"
             # In the MVP implementation, there are only learner_credit subsidies.  Uncomment after subscription
             # subsidies are introduced.
             # "subsidy_type",
@@ -57,11 +60,17 @@ class SubsidySerializer(serializers.ModelSerializer):
             "uuid",
             "starting_balance",
             "current_balance",
+            "total_deposits",
         ]
 
     @extend_schema_field(serializers.IntegerField)
     def get_current_balance(self, obj) -> int:
         return obj.current_balance()
+    
+    @extend_schema_field(serializers.ListField)
+    def get_total_deposits(self, obj) -> list:
+        return obj.total_deposits()
+
 
 
 class ReversalSerializer(serializers.ModelSerializer):

--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -1,7 +1,6 @@
 """
 Serializers for the enterprise-subsidy API.
 """
-import json
 from logging import getLogger
 from urllib.parse import urljoin
 
@@ -67,8 +66,8 @@ class SubsidySerializer(serializers.ModelSerializer):
     def get_current_balance(self, obj) -> int:
         return obj.current_balance()
     
-    @extend_schema_field(serializers.ListField)
-    def get_total_deposits(self, obj) -> list:
+    @extend_schema_field(serializers.IntegerField)
+    def get_total_deposits(self, obj) -> int:
         return obj.total_deposits()
 
 

--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -28,7 +28,9 @@ class SubsidySerializer(serializers.ModelSerializer):
     """
     current_balance = serializers.SerializerMethodField(help_text="The current (remaining) balance of this subsidy.")
     is_active = serializers.BooleanField(read_only=True, help_text="Whether this subsidy is currently active.")
-    total_deposits = serializers.SerializerMethodField(help_text="The aggregate of the initial balance plus all adjustments made on the subsidy in usd cents")
+    total_deposits = serializers.SerializerMethodField(
+        help_text="The aggregate of the initial balance plus all adjustments made on the subsidy in usd cents"
+    )
 
     class Meta:
         """
@@ -65,11 +67,10 @@ class SubsidySerializer(serializers.ModelSerializer):
     @extend_schema_field(serializers.IntegerField)
     def get_current_balance(self, obj) -> int:
         return obj.current_balance()
-    
+
     @extend_schema_field(serializers.IntegerField)
     def get_total_deposits(self, obj) -> int:
         return obj.total_deposits()
-
 
 
 class ReversalSerializer(serializers.ModelSerializer):

--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -14,6 +14,7 @@ from django.core.exceptions import MultipleObjectsReturned
 from edx_rbac.utils import ALL_ACCESS_CONTEXT
 from openedx_ledger.models import Transaction, TransactionStateChoices
 from openedx_ledger.test_utils.factories import (
+    AdjustmentFactory,
     ExternalFulfillmentProviderFactory,
     ExternalTransactionReferenceFactory,
     TransactionFactory
@@ -42,21 +43,29 @@ class APITestBase(APITestMixin):
     enterprise_1_uuid = STATIC_ENTERPRISE_UUID
     enterprise_2_uuid = str(uuid.uuid4())
     enterprise_3_uuid = str(uuid.uuid4())
+    enterprise_4_uuid = str(uuid.uuid4())
     subsidy_1_uuid = str(uuid.uuid4())
     subsidy_2_uuid = str(uuid.uuid4())
     subsidy_3_uuid = str(uuid.uuid4())
     subsidy_4_uuid = str(uuid.uuid4())
+    subsidy_5_uuid = str(uuid.uuid4())
     subsidy_1_transaction_1_uuid = str(uuid.uuid4())
     subsidy_1_transaction_2_uuid = str(uuid.uuid4())
     subsidy_2_transaction_1_uuid = str(uuid.uuid4())
     subsidy_2_transaction_2_uuid = str(uuid.uuid4())
     subsidy_3_transaction_1_uuid = str(uuid.uuid4())
     subsidy_3_transaction_2_uuid = str(uuid.uuid4())
+    subsidy_4_transaction_1_uuid = str(uuid.uuid4())
+    subsidy_4_transaction_2_uuid = str(uuid.uuid4())
+    subsidy_5_transaction_1_uuid = str(uuid.uuid4())
+    subsidy_5_transaction_2_uuid = str(uuid.uuid4())
     subsidy_access_policy_1_uuid = str(uuid.uuid4())
     subsidy_access_policy_2_uuid = str(uuid.uuid4())
     subsidy_access_policy_3_uuid = str(uuid.uuid4())
-    subsidy_4_transaction_1_uuid = str(uuid.uuid4())
-    subsidy_4_transaction_2_uuid = str(uuid.uuid4())
+    subsidy_access_policy_4_uuid = str(uuid.uuid4())
+    adjustment_uuid_1 = str(uuid.uuid4())
+    adjustment_uuid_2 = str(uuid.uuid4())
+
     parent_content_key_1 = "edX+test"
     content_key_1 = "course-v1:edX+test+course.1"
     content_title_1 = "edx: Test Course 1"
@@ -66,6 +75,8 @@ class APITestBase(APITestMixin):
     lms_user_email = 'edx@example.com'
     transaction_quantity_1 = -1
     transaction_quantity_2 = -2
+    adjustment_quantity_1 = 1000
+    adjustment_quantity_2 = -500
 
     def setUp(self):
         super().setUp()
@@ -176,6 +187,25 @@ class APITestBase(APITestMixin):
             lms_user_id=STATIC_LMS_USER_ID+1000,
         )
 
+        # Adjustments
+        self.subsidy_5 = SubsidyFactory(
+            uuid=self.subsidy_5_uuid,
+            enterprise_customer_uuid=self.enterprise_4_uuid,
+            starting_balance=15000
+        )
+        self.subsidy_5_transaction_adjustment_1 = TransactionFactory(
+            uuid=self.subsidy_5_transaction_1_uuid,
+            state=TransactionStateChoices.COMMITTED,
+            quantity=self.adjustment_quantity_1,
+            ledger=self.subsidy_5.ledger,
+        )
+        self.subsidy_5_transaction_1 = AdjustmentFactory(
+            uuid=self.adjustment_uuid_1,
+            transaction=self.subsidy_5_transaction_adjustment_1,
+            adjustment_quantity=1000,
+            ledger=self.subsidy_5.ledger,
+        )
+
         self.all_initial_transactions = set([
             str(self.subsidy_1_transaction_initial.uuid),
             str(self.subsidy_2_transaction_initial.uuid),
@@ -220,6 +250,78 @@ class SubsidyViewSetTests(APITestBase):
         }
         self.assertEqual(expected_result, response.json())
 
+    def test_get_adjustments_related_subsidy(self):
+        """
+        Test that a subsidy detail call returns the expected
+        serialized response when an adjustment has occured.
+        """
+
+        # First transaction with a positive adjustment
+        self.set_up_admin(enterprise_uuids=[self.subsidy_5.enterprise_customer_uuid])
+        response = self.client.get(self.get_details_url([self.subsidy_5.uuid]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_result = {
+            "uuid": str(self.subsidy_5.uuid),
+            "title": self.subsidy_5.title,
+            "enterprise_customer_uuid": str(self.subsidy_5.enterprise_customer_uuid),
+            "active_datetime": self.subsidy_5.active_datetime.strftime(SERIALIZED_DATE_PATTERN),
+            "expiration_datetime": self.subsidy_5.expiration_datetime.strftime(SERIALIZED_DATE_PATTERN),
+            "unit": self.subsidy_5.unit,
+            "reference_id": self.subsidy_5.reference_id,
+            "reference_type": self.subsidy_5.reference_type,
+            "current_balance": self.subsidy_5.current_balance(),
+            "starting_balance": self.subsidy_5.starting_balance,
+            "internal_only": False,
+            "revenue_category": RevenueCategoryChoices.BULK_ENROLLMENT_PREPAY,
+            "is_active": True,
+            "total_deposits": self.subsidy_5.total_deposits(),
+        }
+        total_deposits_including_positive_adjustment = sum(
+            [self.subsidy_5.starting_balance, APITestBase.adjustment_quantity_1]
+        )
+        self.assertEqual(expected_result, response.json())
+        self.assertEqual(expected_result.get('total_deposits'), total_deposits_including_positive_adjustment)
+
+        # Second transaction with a negative Adjustment
+        subsidy_5_transaction_adjustment_2 = TransactionFactory(
+            uuid=self.subsidy_5_transaction_2_uuid,
+            state=TransactionStateChoices.COMMITTED,
+            quantity=self.adjustment_quantity_2,
+            ledger=self.subsidy_5.ledger,
+        )
+        AdjustmentFactory(
+            uuid=self.adjustment_uuid_2,
+            transaction=subsidy_5_transaction_adjustment_2,
+            adjustment_quantity=-500,
+            ledger=self.subsidy_5.ledger,
+        )
+
+        response = self.client.get(self.get_details_url([self.subsidy_5.uuid]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_result = {
+            "uuid": str(self.subsidy_5.uuid),
+            "title": self.subsidy_5.title,
+            "enterprise_customer_uuid": str(self.subsidy_5.enterprise_customer_uuid),
+            "active_datetime": self.subsidy_5.active_datetime.strftime(SERIALIZED_DATE_PATTERN),
+            "expiration_datetime": self.subsidy_5.expiration_datetime.strftime(SERIALIZED_DATE_PATTERN),
+            "unit": self.subsidy_5.unit,
+            "reference_id": self.subsidy_5.reference_id,
+            "reference_type": self.subsidy_5.reference_type,
+            "current_balance": self.subsidy_5.current_balance(),
+            "starting_balance": self.subsidy_5.starting_balance,
+            "internal_only": False,
+            "revenue_category": RevenueCategoryChoices.BULK_ENROLLMENT_PREPAY,
+            "is_active": True,
+            "total_deposits": self.subsidy_5.total_deposits(),
+        }
+
+        total_deposits_including_negative_adjustment = sum(
+            [self.subsidy_5.starting_balance, APITestBase.adjustment_quantity_1, APITestBase.adjustment_quantity_2]
+        )
+
+        self.assertEqual(expected_result, response.json())
+        self.assertEqual(expected_result.get('total_deposits'), total_deposits_including_negative_adjustment)
+
     def test_get_subsidy_list_as_admin(self):
         """"
         Test that a subsidy list call returns the expected
@@ -240,7 +342,7 @@ class SubsidyViewSetTests(APITestBase):
         response = self.client.get(self.get_list_url)
         print(response.json()['results'][0]['uuid'].find(str(self.subsidy_1.uuid)))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()['count'], 4)
+        self.assertEqual(response.json()['count'], 5)
         self.assertEqual(len(response.json()['results']), response.json()['count'])
 
     def test_get_subsidy_list_with_query_parameter_enterprise_customer_uuid(self):

--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -216,6 +216,7 @@ class SubsidyViewSetTests(APITestBase):
             "internal_only": False,
             "revenue_category": RevenueCategoryChoices.BULK_ENROLLMENT_PREPAY,
             "is_active": True,
+            "total_deposits": self.subsidy_1.starting_balance,
         }
         self.assertEqual(expected_result, response.json())
 

--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -21,7 +21,7 @@ from edx_rbac.models import UserRole, UserRoleAssignment
 from edx_rbac.utils import ALL_ACCESS_CONTEXT
 from model_utils.models import TimeStampedModel
 from openedx_ledger import api as ledger_api
-from openedx_ledger.models import Ledger, Transaction, TransactionStateChoices, UnitChoices
+from openedx_ledger.models import Adjustment, Ledger, TransactionStateChoices, UnitChoices
 from openedx_ledger.utils import create_idempotency_key_for_transaction
 from requests.exceptions import HTTPError
 from rest_framework import status
@@ -356,10 +356,10 @@ class Subsidy(TimeStampedModel):
         Returns:
             int: Sum of all adjustments and the starting balance in USD cents.
         """
-        adjustments_for_subsidy = Transaction.objects.filter(adjustment__isnull=False, ledger=self.ledger)
+        adjustments_for_subsidy = Adjustment.objects.filter(ledger=self.ledger)
         total_deposits = sum([
-            transaction.quantity
-            for transaction in adjustments_for_subsidy
+            adjustment.transaction.quantity
+            for adjustment in adjustments_for_subsidy
         ], self.starting_balance)
         return total_deposits
 

--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -21,7 +21,7 @@ from edx_rbac.models import UserRole, UserRoleAssignment
 from edx_rbac.utils import ALL_ACCESS_CONTEXT
 from model_utils.models import TimeStampedModel
 from openedx_ledger import api as ledger_api
-from openedx_ledger.models import Ledger, TransactionStateChoices, UnitChoices, Transaction
+from openedx_ledger.models import Ledger, Transaction, TransactionStateChoices, UnitChoices
 from openedx_ledger.utils import create_idempotency_key_for_transaction
 from requests.exceptions import HTTPError
 from rest_framework import status
@@ -348,11 +348,17 @@ class Subsidy(TimeStampedModel):
 
     def current_balance(self):
         return self.ledger.balance()
-    
+
     def total_deposits(self):
+        """
+        Returns the sum of all adjustments for the subsidy + the starting balance in USD cents.
+
+        Returns:
+            int: Sum of all adjustments and the starting balance in USD cents.
+        """
         adjustments_for_subsidy = Transaction.objects.filter(adjustment__isnull=False, ledger=self.ledger)
         total_deposits = sum([
-            transaction.quantity 
+            transaction.quantity
             for transaction in adjustments_for_subsidy
         ], self.starting_balance)
         return total_deposits

--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -21,7 +21,7 @@ from edx_rbac.models import UserRole, UserRoleAssignment
 from edx_rbac.utils import ALL_ACCESS_CONTEXT
 from model_utils.models import TimeStampedModel
 from openedx_ledger import api as ledger_api
-from openedx_ledger.models import Ledger, TransactionStateChoices, UnitChoices
+from openedx_ledger.models import Ledger, TransactionStateChoices, UnitChoices, Transaction
 from openedx_ledger.utils import create_idempotency_key_for_transaction
 from requests.exceptions import HTTPError
 from rest_framework import status
@@ -226,6 +226,7 @@ class Subsidy(TimeStampedModel):
         on (reference_id, reference_type).  This is necessary
         because MySQL does not support conditional unique constraints.
         """
+        print(self.adjustments_for_subsidy())
         if not self.internal_only:
             other_record = Subsidy.objects.filter(
                 reference_id=self.reference_id,
@@ -348,6 +349,14 @@ class Subsidy(TimeStampedModel):
 
     def current_balance(self):
         return self.ledger.balance()
+    
+    def total_deposits(self):
+        adjustments_for_subsidy = Transaction.objects.filter(adjustment__isnull=False, ledger=self.ledger)
+        total_deposits = sum([
+            transaction.quantity 
+            for transaction in adjustments_for_subsidy
+        ], self.starting_balance)
+        return total_deposits
 
     def create_transaction(
         self,

--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -226,7 +226,6 @@ class Subsidy(TimeStampedModel):
         on (reference_id, reference_type).  This is necessary
         because MySQL does not support conditional unique constraints.
         """
-        print(self.adjustments_for_subsidy())
         if not self.internal_only:
             other_record = Subsidy.objects.filter(
                 reference_id=self.reference_id,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -199,7 +199,7 @@ openedx-events==9.10.0
     #   -r requirements/base.in
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.4.2
+openedx-ledger==1.4.3
     # via -r requirements/base.in
 packaging==24.0
     # via drf-yasg

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -377,7 +377,7 @@ openedx-events==9.10.0
     #   -r requirements/validation.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.4.2
+openedx-ledger==1.4.3
     # via -r requirements/validation.txt
 packaging==24.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -358,7 +358,7 @@ openedx-events==9.10.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.4.2
+openedx-ledger==1.4.3
     # via -r requirements/test.txt
 packaging==24.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -244,7 +244,7 @@ openedx-events==9.10.0
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.4.2
+openedx-ledger==1.4.3
     # via -r requirements/base.txt
 packaging==24.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -339,7 +339,7 @@ openedx-events==9.10.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.4.2
+openedx-ledger==1.4.3
     # via -r requirements/test.txt
 packaging==24.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -285,7 +285,7 @@ openedx-events==9.10.0
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.4.2
+openedx-ledger==1.4.3
     # via -r requirements/base.txt
 packaging==24.0
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -435,7 +435,7 @@ openedx-events==9.10.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.4.2
+openedx-ledger==1.4.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
Aggregates all adjustments and the subsidy `starting_balance` into a net new field labeled `total_deposits` within the Subsidy model as a computed field.

![Screenshot 2024-05-31 at 10 34 56 AM](https://github.com/openedx/enterprise-subsidy/assets/82611798/9ba1d7ed-ed6d-4fc3-bdf6-8238dc6a56a4)

### Description
Describe in a couple of sentences what this PR adds

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
