### PR TITLE
feat: upgrade openedx-events to 9.11, plus other upgrades

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -68,7 +68,7 @@ django==4.2.13
     #   social-auth-app-django
 django-clearcache==1.2.1
     # via -r requirements/base.in
-django-cors-headers==4.3.1
+django-cors-headers==4.4.0
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -187,14 +187,14 @@ mysqlclient==2.2.4
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-newrelic==9.10.0
+newrelic==9.11.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==9.10.0
+openedx-events==9.11.0
     # via
     #   -r requirements/base.in
     #   edx-event-bus-kafka
@@ -207,7 +207,7 @@ pbr==6.0.0
     # via stevedore
 ply==3.11
     # via djangoql
-psutil==5.9.8
+psutil==6.0.0
     # via edx-django-utils
 pycparser==2.22
     # via cffi
@@ -241,7 +241,7 @@ pyyaml==6.0.1
     #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
-redis==5.0.5
+redis==5.0.6
     # via openedx-ledger
 referencing==0.35.1
     # via
@@ -298,7 +298,7 @@ uritemplate==4.1.1
     # via
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,7 +12,7 @@ colorama==0.4.6
     # via tox
 distlib==0.3.8
     # via virtualenv
-filelock==3.14.0
+filelock==3.15.3
     # via
     #   tox
     #   virtualenv

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -18,6 +18,16 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -133,7 +133,7 @@ django==4.2.13
     #   social-auth-app-django
 django-clearcache==1.2.1
     # via -r requirements/validation.txt
-django-cors-headers==4.3.1
+django-cors-headers==4.4.0
     # via -r requirements/validation.txt
 django-crum==0.7.9
     # via
@@ -250,7 +250,7 @@ edx-toggles==5.2.0
     #   edx-event-bus-kafka
 factory-boy==3.3.0
     # via -r requirements/validation.txt
-faker==25.8.0
+faker==25.9.1
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -259,7 +259,7 @@ fastavro==1.9.4
     #   -r requirements/validation.txt
     #   confluent-kafka
     #   openedx-events
-filelock==3.14.0
+filelock==3.15.3
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -358,7 +358,7 @@ mysqlclient==2.2.4
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-newrelic==9.10.0
+newrelic==9.11.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -372,7 +372,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==9.10.0
+openedx-events==9.11.0
     # via
     #   -r requirements/validation.txt
     #   edx-event-bus-kafka
@@ -418,11 +418,11 @@ ply==3.11
     #   djangoql
 polib==1.2.0
     # via edx-i18n-tools
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
-pycodestyle==2.11.1
+pycodestyle==2.12.0
     # via -r requirements/validation.txt
 pycparser==2.22
     # via
@@ -524,7 +524,7 @@ readme-renderer==43.0
     # via
     #   -r requirements/validation.txt
     #   twine
-redis==5.0.5
+redis==5.0.6
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
@@ -554,7 +554,7 @@ requests-toolbelt==1.0.0
     # via
     #   -r requirements/validation.txt
     #   twine
-responses==0.25.2
+responses==0.25.3
     # via -r requirements/validation.txt
 rfc3986==2.0.0
     # via
@@ -639,7 +639,7 @@ uritemplate==4.1.1
     #   -r requirements/validation.txt
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   -r requirements/validation.txt
     #   requests

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -133,7 +133,7 @@ django==4.2.13
     #   social-auth-app-django
 django-clearcache==1.2.1
     # via -r requirements/test.txt
-django-cors-headers==4.3.1
+django-cors-headers==4.4.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -251,7 +251,7 @@ edx-toggles==5.2.0
     #   edx-event-bus-kafka
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==25.8.0
+faker==25.9.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -260,7 +260,7 @@ fastavro==1.9.4
     #   -r requirements/test.txt
     #   confluent-kafka
     #   openedx-events
-filelock==3.14.0
+filelock==3.15.3
     # via
     #   -r requirements/test.txt
     #   tox
@@ -341,7 +341,7 @@ mysqlclient==2.2.4
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==9.10.0
+newrelic==9.11.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -353,7 +353,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==9.10.0
+openedx-events==9.11.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
@@ -391,7 +391,7 @@ ply==3.11
     # via
     #   -r requirements/test.txt
     #   djangoql
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -491,7 +491,7 @@ pyyaml==6.0.1
     #   responses
 readme-renderer==43.0
     # via twine
-redis==5.0.5
+redis==5.0.6
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -520,7 +520,7 @@ requests-oauthlib==2.0.0
     #   social-auth-core
 requests-toolbelt==1.0.0
     # via twine
-responses==0.25.2
+responses==0.25.3
     # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
@@ -574,7 +574,7 @@ sphinx==7.3.7
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==1.1.2
+sphinx-book-theme==1.1.3
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.8
     # via sphinx
@@ -621,7 +621,7 @@ uritemplate==4.1.1
     #   -r requirements/test.txt
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   -r requirements/test.txt
     #   requests

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.43.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.0
+pip==24.1
     # via -r requirements/pip.in
-setuptools==70.0.0
+setuptools==70.1.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -81,7 +81,7 @@ django==4.2.13
     #   social-auth-app-django
 django-clearcache==1.2.1
     # via -r requirements/base.txt
-django-cors-headers==4.3.1
+django-cors-headers==4.4.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -229,7 +229,7 @@ mysqlclient==2.2.4
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   openedx-ledger
-newrelic==9.10.0
+newrelic==9.11.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -239,7 +239,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==9.10.0
+openedx-events==9.11.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -259,7 +259,7 @@ ply==3.11
     # via
     #   -r requirements/base.txt
     #   djangoql
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -310,7 +310,7 @@ pyyaml==6.0.1
     #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
-redis==5.0.5
+redis==5.0.6
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -389,7 +389,7 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -121,7 +121,7 @@ django==4.2.13
     #   social-auth-app-django
 django-clearcache==1.2.1
     # via -r requirements/test.txt
-django-cors-headers==4.3.1
+django-cors-headers==4.4.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -234,7 +234,7 @@ edx-toggles==5.2.0
     #   edx-event-bus-kafka
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==25.8.0
+faker==25.9.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -243,7 +243,7 @@ fastavro==1.9.4
     #   -r requirements/test.txt
     #   confluent-kafka
     #   openedx-events
-filelock==3.14.0
+filelock==3.15.3
     # via
     #   -r requirements/test.txt
     #   tox
@@ -322,7 +322,7 @@ mysqlclient==2.2.4
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==9.10.0
+newrelic==9.11.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -334,7 +334,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==9.10.0
+openedx-events==9.11.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
@@ -369,11 +369,11 @@ ply==3.11
     # via
     #   -r requirements/test.txt
     #   djangoql
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pycodestyle==2.11.1
+pycodestyle==2.12.0
     # via -r requirements/quality.in
 pycparser==2.22
     # via
@@ -465,7 +465,7 @@ pyyaml==6.0.1
     #   responses
 readme-renderer==43.0
     # via twine
-redis==5.0.5
+redis==5.0.6
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -493,7 +493,7 @@ requests-oauthlib==2.0.0
     #   social-auth-core
 requests-toolbelt==1.0.0
     # via twine
-responses==0.25.2
+responses==0.25.3
     # via -r requirements/test.txt
 rfc3986==2.0.0
     # via twine
@@ -569,7 +569,7 @@ uritemplate==4.1.1
     #   -r requirements/test.txt
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   -r requirements/test.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -107,7 +107,7 @@ distlib==0.3.8
     #   social-auth-app-django
 django-clearcache==1.2.1
     # via -r requirements/base.txt
-django-cors-headers==4.3.1
+django-cors-headers==4.4.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -216,14 +216,14 @@ edx-toggles==5.2.0
     #   edx-event-bus-kafka
 factory-boy==3.3.0
     # via -r requirements/test.in
-faker==25.8.0
+faker==25.9.1
     # via factory-boy
 fastavro==1.9.4
     # via
     #   -r requirements/base.txt
     #   confluent-kafka
     #   openedx-events
-filelock==3.14.0
+filelock==3.15.3
     # via
     #   tox
     #   virtualenv
@@ -270,7 +270,7 @@ mysqlclient==2.2.4
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-newrelic==9.10.0
+newrelic==9.11.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -280,7 +280,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==9.10.0
+openedx-events==9.11.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -311,7 +311,7 @@ ply==3.11
     # via
     #   -r requirements/base.txt
     #   djangoql
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -386,7 +386,7 @@ pyyaml==6.0.1
     #   drf-yasg
     #   edx-django-release-util
     #   responses
-redis==5.0.5
+redis==5.0.6
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -410,7 +410,7 @@ requests-oauthlib==2.0.0
     #   -r requirements/base.txt
     #   getsmarter-api-clients
     #   social-auth-core
-responses==0.25.2
+responses==0.25.3
     # via -r requirements/test.in
 rpds-py==0.18.1
     # via
@@ -474,7 +474,7 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -145,7 +145,7 @@ django-clearcache==1.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-cors-headers==4.3.1
+django-cors-headers==4.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -294,7 +294,7 @@ factory-boy==3.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==25.8.0
+faker==25.9.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -305,7 +305,7 @@ fastavro==1.9.4
     #   -r requirements/test.txt
     #   confluent-kafka
     #   openedx-events
-filelock==3.14.0
+filelock==3.15.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -413,7 +413,7 @@ mysqlclient==2.2.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==9.10.0
+newrelic==9.11.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -429,7 +429,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==9.10.0
+openedx-events==9.11.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -474,12 +474,12 @@ ply==3.11
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   djangoql
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-pycodestyle==2.11.1
+pycodestyle==2.12.0
     # via -r requirements/quality.txt
 pycparser==2.22
     # via
@@ -595,7 +595,7 @@ readme-renderer==43.0
     # via
     #   -r requirements/quality.txt
     #   twine
-redis==5.0.5
+redis==5.0.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -629,7 +629,7 @@ requests-toolbelt==1.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-responses==0.25.2
+responses==0.25.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -730,7 +730,7 @@ uritemplate==4.1.1
     #   -r requirements/test.txt
     #   drf-spectacular
     #   drf-yasg
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description
https://github.com/openedx/openedx-events/releases/tag/v9.11.0
Includes new enterprise signals and data classes for `Transaction` events.

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
