### PR TITLE
build: use a modern memcached image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   mysql80:
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
@@ -15,7 +14,7 @@ services:
       - enterprise_subsidy_mysql80:/var/lib/mysql
 
   memcache:
-    image: memcached:1.4.24
+    image: memcached:1.6.6
     container_name: enterprise-subsidy.memcache
     networks:
       - devstack_default


### PR DESCRIPTION
### Description
also deletes deprecated `version` key from `docker-compose.yml`
