### PR TITLE
chore: re-enable openedx-events package in base.in

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -22,7 +22,7 @@ edx-rbac
 edx-rest-api-client
 jsonfield2
 mysqlclient
-# openedx-events
+openedx-events
 openedx-ledger
 pymemcache
 pytz
@@ -32,4 +32,4 @@ django-log-request-id
 django-clearcache
 
 # Temporary pin to a fork to use new enterprise events
-git+https://github.com/iloveagent57/openedx-events.git@67d7bc392af88996ca1e63d789c6017248dac305
+# git+https://github.com/iloveagent57/openedx-events.git@67d7bc392af88996ca1e63d789c6017248dac305


### PR DESCRIPTION
### Description
Comments out pinned repo for openedx-events library while so python requirement upgrades can be ran against the repo. 

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
