### PR TITLE
fix: make deposit backfill migration defensive against bogus subsidy reference type

### DIFF
--- a/enterprise_subsidy/apps/subsidy/migrations/0022_backfill_initial_deposits.py
+++ b/enterprise_subsidy/apps/subsidy/migrations/0022_backfill_initial_deposits.py
@@ -53,7 +53,10 @@ def forwards_func(apps, schema_editor):
         sales_contract_reference_provider = None
         try:
             sales_contract_reference_id = tx.ledger.subsidy.reference_id
-            sales_contract_reference_provider = sales_contract_reference_providers[tx.ledger.subsidy.reference_type]
+            # If a pre-established provider is not found, that means it was not defined in
+            # SubsidyReferenceChoices.CHOICES.  We don't really want to pollute the SalesContractReferenceProvider table
+            # with unofficial test records, so the compromise is to just use get() and fallback to NULL.
+            sales_contract_reference_provider = sales_contract_reference_providers.get(tx.ledger.subsidy.reference_type)
         except Ledger.subsidy.RelatedObjectDoesNotExist:
             logger.warning(
                 "Found a ledger (%s) without a related subsidy, so the initial deposit will not have a sales contract.",


### PR DESCRIPTION
ENT-9075

This is safe (i.e. no meaningful data loss) in both stage and prod because we only ever used opportunity_product_id for an internal subsidy.

stage:
```
mysql> select reference_type, internal_only, max(created), count(*) from subsidy_subsidy group by reference_type, internal_only;
+----------------------------------+---------------+----------------------------+----------+
| reference_type                   | internal_only | max(created)               | count(*) |
+----------------------------------+---------------+----------------------------+----------+
| salesforce_opportunity_line_item |             0 | 2024-04-08 15:23:46.105183 |       11 |
| salesforce_opportunity_line_item |             1 | 2024-06-17 13:40:43.371173 |      148 |
| opportunity_product_id           |             1 | 2023-03-28 19:50:03.368324 |        1 |
+----------------------------------+---------------+----------------------------+----------+
3 rows in set (0.00 sec)
```
prod:
```
mysql> select reference_type, internal_only, max(created), count(*) from subsidy_subsidy group by reference_type, internal_only;
+----------------------------------+---------------+----------------------------+----------+
| reference_type                   | internal_only | max(created)               | count(*) |
+----------------------------------+---------------+----------------------------+----------+
| salesforce_opportunity_line_item |             0 | 2024-07-10 20:15:54.353782 |      176 |
| salesforce_opportunity_line_item |             1 | 2024-07-01 17:07:13.888752 |      122 |
| opportunity_product_id           |             1 | 2023-03-29 18:03:51.268438 |        1 |
+----------------------------------+---------------+----------------------------+----------+
3 rows in set (0.00 sec)
```