### PR TITLE
fix: correcting next var in pagination

### DIFF
--- a/enterprise_subsidy/settings/production.py
+++ b/enterprise_subsidy/settings/production.py
@@ -8,6 +8,14 @@ from enterprise_subsidy.settings.utils import get_env_setting
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
+# IMPORTANT: With this enabled, the server must always be behind a proxy that
+# strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
+# a user can fool our server into thinking it was an https connection.
+# See
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+# for other warnings.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 ALLOWED_HOSTS = ['*']
 
 LOGGING = get_logger_config()


### PR DESCRIPTION
### Description
By adding the variable in production, we are making sure that the "next" variable that shows up when an API response is paginated defaults to HTTPS instead of HTTP. 

[More information in the Jira ticket. ](https://2u-internal.atlassian.net/browse/ENT-9225)

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
