### PR TITLE
fix: openedx-ledger to 1.5.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -199,7 +199,7 @@ openedx-events==9.11.0
     #   -r requirements/base.in
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.5
+openedx-ledger==1.5.6
     # via -r requirements/base.in
 packaging==24.1
     # via drf-yasg

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -8,6 +8,11 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -252,7 +252,7 @@ edx-toggles==5.2.0
     #   edx-event-bus-kafka
 factory-boy==3.3.0
     # via -r requirements/validation.txt
-faker==26.3.0
+faker==27.0.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -375,7 +375,7 @@ openedx-events==9.11.0
     #   -r requirements/validation.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.5
+openedx-ledger==1.5.6
     # via -r requirements/validation.txt
 packaging==24.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -253,7 +253,7 @@ edx-toggles==5.2.0
     #   edx-event-bus-kafka
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==26.3.0
+faker==27.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -358,7 +358,7 @@ openedx-events==9.11.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.5
+openedx-ledger==1.5.6
     # via -r requirements/test.txt
 packaging==24.1
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -244,7 +244,7 @@ openedx-events==9.11.0
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.5
+openedx-ledger==1.5.6
     # via -r requirements/base.txt
 packaging==24.1
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -236,7 +236,7 @@ edx-toggles==5.2.0
     #   edx-event-bus-kafka
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==26.3.0
+faker==27.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -339,7 +339,7 @@ openedx-events==9.11.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.5
+openedx-ledger==1.5.6
     # via -r requirements/test.txt
 packaging==24.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -219,7 +219,7 @@ edx-toggles==5.2.0
     #   edx-event-bus-kafka
 factory-boy==3.3.0
     # via -r requirements/test.in
-faker==26.3.0
+faker==27.0.0
     # via factory-boy
 fastavro==1.9.5
     # via
@@ -288,7 +288,7 @@ openedx-events==9.11.0
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.5
+openedx-ledger==1.5.6
     # via -r requirements/base.txt
 packaging==24.1
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -298,7 +298,7 @@ factory-boy==3.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==26.3.0
+faker==27.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -439,7 +439,7 @@ openedx-events==9.11.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.5
+openedx-ledger==1.5.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description
Installs https://github.com/openedx/openedx-ledger/pull/107

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
