### PR TITLE
build: unpin DRF

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -106,9 +106,8 @@ djangoql==0.18.1
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   drf-jwt
     #   drf-spectacular
@@ -199,7 +198,7 @@ openedx-events==9.11.0
     #   -r requirements/base.in
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.6
+openedx-ledger==1.5.7
     # via -r requirements/base.in
 packaging==24.1
     # via drf-yasg
@@ -231,7 +230,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/base.in
-    #   djangorestframework
     #   drf-yasg
     #   getsmarter-api-clients
     #   openedx-ledger

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.4.0
+cachetools==5.5.0
     # via tox
 chardet==5.2.0
     # via tox
@@ -28,7 +28,7 @@ pluggy==1.5.0
     # via tox
 pyproject-api==1.7.1
     # via tox
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/ci.in
 virtualenv==20.26.3
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -13,6 +13,11 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,8 +13,3 @@
 
 # django-simple-history>3.4.0 for this repo... we were not concerned about migration issues
 django-simple-history>=3.4.0,<3.5.0
-
-# DRF 3.15.0 is providing some backwards-compatibility issues for us
-# around default model fields vs. the serializer field defs,
-# and the discontinued use of OrderedDict in serializers.
-djangorestframework<3.15

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ build==1.2.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==5.4.0
+cachetools==5.5.0
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -181,7 +181,7 @@ djangoql==0.18.1
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
     #   -r requirements/validation.txt
     #   drf-jwt
@@ -250,7 +250,7 @@ edx-toggles==5.2.0
     # via
     #   -r requirements/validation.txt
     #   edx-event-bus-kafka
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/validation.txt
 faker==27.0.0
     # via
@@ -375,7 +375,7 @@ openedx-events==9.11.0
     #   -r requirements/validation.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.6
+openedx-ledger==1.5.7
     # via -r requirements/validation.txt
 packaging==24.1
     # via
@@ -505,7 +505,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/validation.txt
-    #   djangorestframework
     #   drf-yasg
     #   getsmarter-api-clients
     #   openedx-ledger
@@ -620,11 +619,11 @@ text-unidecode==1.3
     # via
     #   -r requirements/validation.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/validation.txt
     #   pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/validation.txt
 twine==5.1.1
     # via -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -36,7 +36,7 @@ beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
 build==1.2.1
     # via -r requirements/doc.in
-cachetools==5.4.0
+cachetools==5.5.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -178,9 +178,8 @@ djangoql==0.18.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   drf-jwt
     #   drf-spectacular
@@ -251,7 +250,7 @@ edx-toggles==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.txt
 faker==27.0.0
     # via
@@ -358,7 +357,7 @@ openedx-events==9.11.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.6
+openedx-ledger==1.5.7
     # via -r requirements/test.txt
 packaging==24.1
     # via
@@ -477,7 +476,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/test.txt
-    #   djangorestframework
     #   drf-yasg
     #   getsmarter-api-clients
     #   openedx-ledger
@@ -567,7 +565,7 @@ social-auth-core==4.5.4
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 sphinx==8.0.2
     # via
@@ -603,11 +601,11 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/test.txt
 twine==5.1.1
     # via -r requirements/doc.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.44.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via -r requirements/pip.in
-setuptools==72.1.0
+setuptools==72.2.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -121,7 +121,7 @@ djangoql==0.18.1
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -244,7 +244,7 @@ openedx-events==9.11.0
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.6
+openedx-ledger==1.5.7
     # via -r requirements/base.txt
 packaging==24.1
     # via
@@ -298,7 +298,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/base.txt
-    #   djangorestframework
     #   drf-yasg
     #   getsmarter-api-clients
     #   openedx-ledger

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -24,7 +24,7 @@ avro==1.12.0
     # via
     #   -r requirements/test.txt
     #   confluent-kafka
-cachetools==5.4.0
+cachetools==5.5.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -166,9 +166,8 @@ djangoql==0.18.1
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   drf-jwt
     #   drf-spectacular
@@ -234,7 +233,7 @@ edx-toggles==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.txt
 faker==27.0.0
     # via
@@ -339,7 +338,7 @@ openedx-events==9.11.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.6
+openedx-ledger==1.5.7
     # via -r requirements/test.txt
 packaging==24.1
     # via
@@ -451,7 +450,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/test.txt
-    #   djangorestframework
     #   drf-yasg
     #   getsmarter-api-clients
     #   openedx-ledger
@@ -552,11 +550,11 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/test.txt
 twine==5.1.1
     # via -r requirements/quality.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -23,7 +23,7 @@ avro==1.12.0
     # via
     #   -r requirements/base.txt
     #   confluent-kafka
-cachetools==5.4.0
+cachetools==5.5.0
     # via tox
 certifi==2024.7.4
     # via
@@ -153,9 +153,8 @@ djangoql==0.18.1
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   drf-jwt
     #   drf-spectacular
@@ -217,7 +216,7 @@ edx-toggles==5.2.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.in
 faker==27.0.0
     # via factory-boy
@@ -288,7 +287,7 @@ openedx-events==9.11.0
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.6
+openedx-ledger==1.5.7
     # via -r requirements/base.txt
 packaging==24.1
     # via
@@ -377,7 +376,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/base.txt
-    #   djangorestframework
     #   drf-yasg
     #   getsmarter-api-clients
     #   openedx-ledger
@@ -464,9 +462,9 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/test.in
 typing-extensions==4.12.2
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -28,7 +28,7 @@ avro==1.12.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   confluent-kafka
-cachetools==5.4.0
+cachetools==5.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -205,7 +205,7 @@ djangoql==0.18.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -294,7 +294,7 @@ edx-toggles==5.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -439,7 +439,7 @@ openedx-events==9.11.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.5.6
+openedx-ledger==1.5.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -582,7 +582,6 @@ pytz==2024.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   djangorestframework
     #   drf-yasg
     #   getsmarter-api-clients
     #   openedx-ledger
@@ -712,12 +711,12 @@ text-unidecode==1.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-tox==4.17.1
+tox==4.18.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description
We had pinned DRF because version 3.15.0 was problematic/non-backwards-compatible. That's been fixed in DRF >= 3.15.1

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
