### PR TITLE
fix: content_metadata enroll_by_date only drawn from course runs.

### DIFF
--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -1690,6 +1690,17 @@ class ContentMetadataViewSetTests(APITestBase):
                 "key": course_run_key,
                 "uuid": course_run_uuid,
                 "first_enrollable_paid_seat_price": 100,
+                "seats": [
+                    {
+                        "type": "verified",
+                        "upgrade_deadline_override": "2025-01-01T00:00:00Z",
+                        "upgrade_deadline": "2024-01-01T00:00:00Z",
+                    },
+                    {
+                        "type": "audit",
+                        "upgrade_deadline": None,
+                    },
+                ],
             }
         ],
         "advertised_course_run_uuid": course_run_uuid,
@@ -1719,6 +1730,7 @@ class ContentMetadataViewSetTests(APITestBase):
                 "key": course_run_key,
                 "uuid": course_run_uuid,
                 "variant_id": "79a95406-a9ac-49b3-a27c-44f3fd06092e",
+                "enrollment_end": "2024-01-01T00:00:00Z",
             }
         ],
         "advertised_course_run_uuid": course_run_uuid,
@@ -1738,6 +1750,7 @@ class ContentMetadataViewSetTests(APITestBase):
             'expected_source': 'edX',
             'expected_mode': 'verified',
             'expected_geag_variant_id': None,
+            'expected_enroll_by_date': None,
         },
         {
             'expected_content_title': content_title,
@@ -1750,6 +1763,7 @@ class ContentMetadataViewSetTests(APITestBase):
             'expected_source': 'edX',
             'expected_mode': 'verified',
             'expected_geag_variant_id': None,
+            'expected_enroll_by_date': '2025-01-01T00:00:00Z',
         },
         {
             'expected_content_title': content_title,
@@ -1763,6 +1777,7 @@ class ContentMetadataViewSetTests(APITestBase):
             'expected_mode': 'paid-executive-education',
             # generated randomly using a fair die
             'expected_geag_variant_id': '79a95406-a9ac-49b3-a27c-44f3fd06092e',
+            'expected_enroll_by_date': '2024-01-01T00:00:00Z',
         },
     )
     @ddt.unpack
@@ -1778,6 +1793,7 @@ class ContentMetadataViewSetTests(APITestBase):
         expected_source,
         expected_mode,
         expected_geag_variant_id,
+        expected_enroll_by_date,
     ):
         with mock.patch(
             'enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient',
@@ -1803,7 +1819,7 @@ class ContentMetadataViewSetTests(APITestBase):
                 'content_price': expected_content_price,
                 'mode': expected_mode,
                 'geag_variant_id': expected_geag_variant_id,
-                'enroll_by_date': None,
+                'enroll_by_date': expected_enroll_by_date,
             }
 
             # Now make a second call to validate that the view-level cache is utilized.
@@ -1825,7 +1841,7 @@ class ContentMetadataViewSetTests(APITestBase):
                 'content_price': expected_content_price,
                 'mode': expected_mode,
                 'geag_variant_id': expected_geag_variant_id,
-                'enroll_by_date': None,
+                'enroll_by_date': expected_enroll_by_date,
             }
             # Validate that, in the first, non-cached request, we call
             # the enterprise catalog endpoint via the client, and that

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -124,29 +124,24 @@ class ContentMetadataApi:
                 variant_id = additional_metadata.get('variant_id')
         return variant_id
 
-    def enroll_by_date_for_content(self, content_data, content_mode):
+    def enroll_by_date_for_content(self, course_run_data, content_mode):
         """
-        Determines the enrollment deadline for the given ``content_data``,
-        which could be either a course or course run, hence the branching
-        on content type below.
+        Determines the enrollment deadline for the given ``course_run_data``.
 
         Args:
-            content_data: A dictionary of metadata pertaining to a course or course run.
-            content_mode: The (already computed) course mode for the content.
+            course_run_data: A dictionary of metadata pertaining to a course run.
+            content_mode: The (already computed) course mode for the course run.
 
         Returns:
             A datetime string, or possibly null.
         """
-        if content_data.get('content_type') == 'course':
-            return content_data.get('normalized_metadata', {}).get('enroll_by_date')
-
         # For edx-verified mode course runs, first try to extract
         # the verified upgrade deadline from the course run's seat
         # associated with the given content_mode
         upgrade_deadline = None
         if content_mode == CourseModes.EDX_VERIFIED.value:
             seats_for_mode = [
-                seat for seat in content_data.get('seats', [])
+                seat for seat in course_run_data.get('seats', [])
                 if seat.get('type') == content_mode
             ]
             if seats_for_mode:
@@ -156,7 +151,7 @@ class ContentMetadataApi:
         # Return the upgrade deadline. If no such deadline exists,
         # or if we're dealing with another course mode (e.g. exec ed),
         # use the `enrollment_end` of the course run.
-        return upgrade_deadline or content_data.get('enrollment_end')
+        return upgrade_deadline or course_run_data.get('enrollment_end')
 
     def summary_data_for_content(self, content_identifier, content_data):
         """
@@ -174,7 +169,7 @@ class ContentMetadataApi:
             'source': self.product_source_for_content(content_data),
             'mode': content_mode,
             'content_price': self.price_for_content(content_data, course_run_content),
-            'enroll_by_date': self.enroll_by_date_for_content(content_data, content_mode),
+            'enroll_by_date': self.enroll_by_date_for_content(course_run_content, content_mode),
             'geag_variant_id': self.get_geag_variant_id_for_content(content_identifier, content_data),
         }
 

--- a/enterprise_subsidy/apps/content_metadata/tests/test_api.py
+++ b/enterprise_subsidy/apps/content_metadata/tests/test_api.py
@@ -109,12 +109,14 @@ class ContentMetadataApiTests(TestCase):
                     "uuid": str(cls.courserun_uuid_1),
                     "title": "Demonstration Exec Ed Course",
                     "variant_id": cls.variant_id_1,
+                    "enrollment_end": "2023-06-24T00:00:00.000000Z",
                 },
                 {
                     "key": cls.courserun_key_2,
                     "uuid": str(cls.courserun_uuid_2),
                     "title": "Demonstration Exec Ed Course",
                     "variant_id": cls.variant_id_2,
+                    "enrollment_end": "2024-06-24T00:00:00.000000Z",
                 },
             ],
             "course_run_keys": [
@@ -138,9 +140,6 @@ class ContentMetadataApiTests(TestCase):
             },
             "additional_metadata": {
                 "variant_id": cls.variant_id_2,
-            },
-            "normalized_metadata": {
-                "enroll_by_date": "2024-01-01T00:00:00Z",
             },
         }
 
@@ -247,6 +246,7 @@ class ContentMetadataApiTests(TestCase):
         assert summary.get('course_run_key') is self.courserun_key_1
         assert summary.get('content_price') == 59949
         assert summary.get('geag_variant_id') == self.variant_id_1
+        assert summary.get('enroll_by_date') == '2023-06-24T00:00:00.000000Z'
 
         # Test assembling summary data given an identifier of an advertised course run.
         # Note, the result should be identical to when a course identifier is given.
@@ -258,7 +258,7 @@ class ContentMetadataApiTests(TestCase):
         assert summary.get('course_run_key') is self.courserun_key_2
         assert summary.get('content_price') == 59949
         assert summary.get('geag_variant_id') == self.variant_id_2
-        assert summary.get('enroll_by_date') == '2024-01-01T00:00:00Z'
+        assert summary.get('enroll_by_date') == '2024-06-24T00:00:00.000000Z'
 
     @ddt.data(
         {


### PR DESCRIPTION
Since we *always* have a course run within the scope of `summary_data_for_content()` executions, the enroll by date should always be determined directly from a course run record, and not from the *course's* `normalized_metadata` dictionary (the latter of which will always contain the advertised run's enrollment deadline, regardless of the *requested* course run - we typically request course runs, and not courses, of this endpoint in prod). 
ENT-7472

### Description
The enterprise-subsidy CM endpoint calls the catalog customer CM endpoint.  If you pass the latter (catalog-customer-cm endpoint) a course run, you'll typically get a top-level _course_ back, with course runs inside of it. So despite typically receiving runs as input to the subsidy CM API, within the bounds of `summary_data_for_content()`, `content_data` is usually a course, not a run (because it's fetched from the catalog-customer-cm endpoint).

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
