### PR TITLE
fix: compute price more defensively

### DIFF
--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -1741,19 +1741,6 @@ class ContentMetadataViewSetTests(APITestBase):
     @ddt.data(
         {
             'expected_content_title': content_title,
-            'expected_content_uuid': content_uuid_1,
-            'expected_content_key': content_key_1,
-            'expected_course_run_uuid': None,
-            'expected_course_run_key': None,
-            'expected_content_price': 14900.0,
-            'mock_metadata': edx_course_metadata,
-            'expected_source': 'edX',
-            'expected_mode': 'verified',
-            'expected_geag_variant_id': None,
-            'expected_enroll_by_date': None,
-        },
-        {
-            'expected_content_title': content_title,
             'expected_content_uuid': content_uuid_3,
             'expected_content_key': content_key_3,
             'expected_course_run_uuid': str(course_run_uuid),

--- a/enterprise_subsidy/apps/content_metadata/constants.py
+++ b/enterprise_subsidy/apps/content_metadata/constants.py
@@ -18,3 +18,6 @@ class CourseModes(Enum):
     """
     EDX_VERIFIED = "verified"  # e.g. edX Verified Courses
     EXECUTIVE_EDUCATION = "paid-executive-education"  # e.g. ExecEd courses
+
+
+DEFAULT_CONTENT_PRICE = 0.0


### PR DESCRIPTION
ENT-8786

### Description
* Price for content now handles the "exceptional" case (a twou EE course) first.
* All content prices now default to 0.0 if their value would otherwise be null/falsey.

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
