### PR TITLE
feat: retrieve content_price from normalized_metadata_by_run

### DIFF
--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -1705,6 +1705,11 @@ class ContentMetadataViewSetTests(APITestBase):
         ],
         "advertised_course_run_uuid": course_run_uuid,
         "product_source": None,
+        "normalized_metadata_by_run": {
+            "edX+DemoX3+20230101": {
+                "content_price": 100.0
+            }
+        }
     }
     executive_education_course_metadata = {
         "key": content_key_2,
@@ -1734,6 +1739,11 @@ class ContentMetadataViewSetTests(APITestBase):
             }
         ],
         "advertised_course_run_uuid": course_run_uuid,
+        "normalized_metadata_by_run": {
+            "edX+DemoX3+20230101": {
+                "content_price": 599.49
+            }
+        }
     }
     mock_http_error_reason = 'Something Went Wrong'
     mock_http_error_url = 'foobar.com'
@@ -1745,7 +1755,7 @@ class ContentMetadataViewSetTests(APITestBase):
             'expected_content_key': content_key_3,
             'expected_course_run_uuid': str(course_run_uuid),
             'expected_course_run_key': course_run_key,
-            'expected_content_price': 10000.0,
+            'expected_content_price': 10000,
             'mock_metadata': edx_course_metadata_with_runs,
             'expected_source': 'edX',
             'expected_mode': 'verified',

--- a/enterprise_subsidy/apps/content_metadata/tests/test_api.py
+++ b/enterprise_subsidy/apps/content_metadata/tests/test_api.py
@@ -94,6 +94,11 @@ class ContentMetadataApiTests(TestCase):
             'normalized_metadata': {
                 'enroll_by_date': '2023-05-26T15:45:32.494051Z',
             },
+            "normalized_metadata_by_run": {
+                "course-v1:edX+DemoX+Demo_Course.1": {
+                    "content_price": 149.0
+                }
+            }
         }
 
         cls.executive_education_course_metadata = {
@@ -139,6 +144,14 @@ class ContentMetadataApiTests(TestCase):
             "additional_metadata": {
                 "variant_id": cls.variant_id_2,
             },
+            "normalized_metadata_by_run": {
+                "course-v1:edX+DemoX+Demo_Course.1": {
+                    "content_price": 599.49
+                },
+                "course-v1:edX+DemoX+Demo_Course.2": {
+                    "content_price": 599.49
+                }
+            }
         }
 
     @ddt.data(


### PR DESCRIPTION
### Description
The `price_for_content` logic updated to look for the net new field `normalized_metadata_by_run` which is included as part of these series of PRs.

https://github.com/openedx/enterprise-catalog/pull/930
https://github.com/openedx/enterprise-catalog/pull/931

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
