### PR TITLE
feat: add created date to subsidy serializer

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -51,7 +51,9 @@ class SubsidySerializer(serializers.ModelSerializer):
             "internal_only",
             "revenue_category",
             "is_active",
-            "total_deposits"
+            "total_deposits",
+            "created",
+            "modified",
             # In the MVP implementation, there are only learner_credit subsidies.  Uncomment after subscription
             # subsidies are introduced.
             # "subsidy_type",

--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -247,6 +247,8 @@ class SubsidyViewSetTests(APITestBase):
             "revenue_category": RevenueCategoryChoices.BULK_ENROLLMENT_PREPAY,
             "is_active": True,
             "total_deposits": self.subsidy_1.starting_balance,
+            "created": self.subsidy_1.created.strftime(SERIALIZED_DATE_PATTERN),
+            "modified": self.subsidy_1.modified.strftime(SERIALIZED_DATE_PATTERN),
         }
         self.assertEqual(expected_result, response.json())
 
@@ -275,6 +277,8 @@ class SubsidyViewSetTests(APITestBase):
             "revenue_category": RevenueCategoryChoices.BULK_ENROLLMENT_PREPAY,
             "is_active": True,
             "total_deposits": self.subsidy_5.total_deposits,
+            "created": self.subsidy_5.created.strftime(SERIALIZED_DATE_PATTERN),
+            "modified": self.subsidy_5.modified.strftime(SERIALIZED_DATE_PATTERN),
         }
         total_deposits_including_positive_adjustment = sum(
             [self.subsidy_5.starting_balance, APITestBase.adjustment_quantity_1]
@@ -313,6 +317,8 @@ class SubsidyViewSetTests(APITestBase):
             "revenue_category": RevenueCategoryChoices.BULK_ENROLLMENT_PREPAY,
             "is_active": True,
             "total_deposits": self.subsidy_5.total_deposits,
+            "created": self.subsidy_5.created.strftime(SERIALIZED_DATE_PATTERN),
+            "modified": self.subsidy_5.modified.strftime(SERIALIZED_DATE_PATTERN),
         }
 
         total_deposits_including_negative_adjustment = sum(


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-9498

<img width="1502" alt="Screenshot 2024-09-13 at 1 38 56 PM" src="https://github.com/user-attachments/assets/0c5cd1e4-a850-4b32-8fa4-384f5c5818df">

# Test plan
1. Add a subsidy to http://localhost:18280/admin/subsidy/subsidy/
2. check that the api response from the subsidy you just created returns "created" http://localhost:18280/api/v1/subsidies/?enterprise_customer_uuid=<enterprise_customer_uuid>


### Description
Describe in a couple of sentences what this PR adds

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
