### PR TITLE
build: pin confluent-kafka<2.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ dev.stop: # Stops containers so they can be restarted
 	docker-compose stop
 
 app-shell: # Run the app shell as root
-	docker exec -u 0 -it enterprise-subsidy.app bash
+	docker exec -u 0 -it enterprise-subsidy.app bash -c "cd /edx/app/enterprise-subsidy && bash"
 
 db-shell-57: # Run the mysql 5.7 shell as root, enter the app's database
 	docker exec -u 0 -it enterprise-subsidy.db mysql -u root enterprise_subsidy

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,27 +4,19 @@
 #
 #    make upgrade
 #
-anyio==4.8.0
-    # via httpx
 asgiref==3.8.1
     # via
     #   django
     #   django-cors-headers
 attrs==24.3.0
     # via
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
 avro==1.12.0
     # via confluent-kafka
-cachetools==5.5.0
-    # via confluent-kafka
 certifi==2024.12.14
-    # via
-    #   httpcore
-    #   httpx
-    #   requests
+    # via requests
 cffi==1.17.1
     # via
     #   cryptography
@@ -37,8 +29,10 @@ click==8.1.8
     #   edx-django-utils
 code-annotations==2.1.0
     # via edx-toggles
-confluent-kafka[avro,schema-registry]==2.7.0
-    # via -r requirements/base.in
+confluent-kafka[avro,schema-registry]==2.6.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 cryptography==44.0.0
     # via
     #   pyjwt
@@ -172,17 +166,8 @@ fastavro==1.10.0
     #   openedx-events
 getsmarter-api-clients==0.6.1
     # via -r requirements/base.in
-h11==0.14.0
-    # via httpcore
-httpcore==1.0.7
-    # via httpx
-httpx==0.27.2
-    # via confluent-kafka
 idna==3.10
-    # via
-    #   anyio
-    #   httpx
-    #   requests
+    # via requests
 inflection==0.5.1
     # via
     #   drf-spectacular
@@ -289,10 +274,6 @@ six==1.17.0
     #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-rbac
-sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
 social-auth-app-django==5.4.2
     # via edx-auth-backends
 social-auth-core==4.5.4
@@ -309,9 +290,7 @@ stevedore==5.4.0
 text-unidecode==1.3
     # via python-slugify
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   edx-opaque-keys
+    # via edx-opaque-keys
 uritemplate==4.1.1
     # via
     #   drf-spectacular

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -3,6 +3,16 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,6 @@
 
 # django-simple-history>3.4.0 for this repo... we were not concerned about migration issues
 django-simple-history>=3.4.0,<3.5.0
+
+# confluent-kafka 2.7.0 increased CPU usage
+confluent-kafka<2.6.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
-anyio==4.8.0
-    # via
-    #   -r requirements/validation.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r requirements/validation.txt
@@ -21,7 +17,6 @@ astroid==3.3.8
 attrs==24.3.0
     # via
     #   -r requirements/validation.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
@@ -36,13 +31,10 @@ build==1.2.2.post1
 cachetools==5.5.0
     # via
     #   -r requirements/validation.txt
-    #   confluent-kafka
     #   tox
 certifi==2024.12.14
     # via
     #   -r requirements/validation.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -80,7 +72,7 @@ colorama==0.4.6
     # via
     #   -r requirements/validation.txt
     #   tox
-confluent-kafka[avro,schema-registry]==2.7.0
+confluent-kafka[avro,schema-registry]==2.6.1
     # via -r requirements/validation.txt
 coverage[toml]==7.6.10
     # via
@@ -276,23 +268,9 @@ filelock==3.16.1
     #   virtualenv
 getsmarter-api-clients==0.6.1
     # via -r requirements/validation.txt
-h11==0.14.0
-    # via
-    #   -r requirements/validation.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r requirements/validation.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r requirements/validation.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r requirements/validation.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -451,7 +429,7 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/validation.txt
-pygments==2.19.0
+pygments==2.19.1
     # via
     #   -r requirements/validation.txt
     #   diff-cover
@@ -609,11 +587,6 @@ six==1.17.0
     #   edx-lint
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r requirements/validation.txt
-    #   anyio
-    #   httpx
 snowballstemmer==2.2.0
     # via
     #   -r requirements/validation.txt
@@ -653,7 +626,6 @@ twine==6.0.1
 typing-extensions==4.12.2
     # via
     #   -r requirements/validation.txt
-    #   anyio
     #   django-test-migrations
     #   edx-opaque-keys
     #   faker

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,10 +8,6 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
-anyio==4.8.0
-    # via
-    #   -r requirements/test.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r requirements/test.txt
@@ -25,7 +21,6 @@ astroid==3.3.8
 attrs==24.3.0
     # via
     #   -r requirements/test.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
@@ -44,13 +39,10 @@ build==1.2.2.post1
 cachetools==5.5.0
     # via
     #   -r requirements/test.txt
-    #   confluent-kafka
     #   tox
 certifi==2024.12.14
     # via
     #   -r requirements/test.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -85,8 +77,10 @@ colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-confluent-kafka[avro,schema-registry]==2.7.0
-    # via -r requirements/test.txt
+confluent-kafka[avro,schema-registry]==2.6.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 coverage[toml]==7.6.10
     # via
     #   -r requirements/test.txt
@@ -276,23 +270,9 @@ filelock==3.16.1
     #   virtualenv
 getsmarter-api-clients==0.6.1
     # via -r requirements/test.txt
-h11==0.14.0
-    # via
-    #   -r requirements/test.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r requirements/test.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r requirements/test.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r requirements/test.txt
-    #   anyio
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
@@ -420,7 +400,7 @@ pycparser==2.22
     #   cffi
 pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
-pygments==2.19.0
+pygments==2.19.1
     # via
     #   accessible-pygments
     #   doc8
@@ -569,11 +549,6 @@ six==1.17.0
     #   edx-lint
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r requirements/test.txt
-    #   anyio
-    #   httpx
 snowballstemmer==2.2.0
     # via sphinx
 social-auth-app-django==5.4.2
@@ -632,7 +607,6 @@ twine==6.0.1
 typing-extensions==4.12.2
     # via
     #   -r requirements/test.txt
-    #   anyio
     #   django-test-migrations
     #   edx-opaque-keys
     #   faker

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/enterprise-subsidy/enterprise-subsidy/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
 setuptools==75.7.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
-anyio==4.8.0
-    # via
-    #   -r requirements/base.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r requirements/base.txt
@@ -16,7 +12,6 @@ asgiref==3.8.1
 attrs==24.3.0
     # via
     #   -r requirements/base.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
@@ -24,15 +19,9 @@ avro==1.12.0
     # via
     #   -r requirements/base.txt
     #   confluent-kafka
-cachetools==5.5.0
-    # via
-    #   -r requirements/base.txt
-    #   confluent-kafka
 certifi==2024.12.14
     # via
     #   -r requirements/base.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -52,7 +41,7 @@ code-annotations==2.1.0
     # via
     #   -r requirements/base.txt
     #   edx-toggles
-confluent-kafka[avro,schema-registry]==2.7.0
+confluent-kafka[avro,schema-registry]==2.6.1
     # via -r requirements/base.txt
 cryptography==44.0.0
     # via
@@ -206,23 +195,9 @@ greenlet==3.1.1
     # via gevent
 gunicorn==23.0.0
     # via -r requirements/production.in
-h11==0.14.0
-    # via
-    #   -r requirements/base.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r requirements/base.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r requirements/base.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r requirements/base.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -376,11 +351,6 @@ six==1.17.0
     #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-rbac
-sniffio==1.3.1
-    # via
-    #   -r requirements/base.txt
-    #   anyio
-    #   httpx
 social-auth-app-django==5.4.2
     # via
     #   -r requirements/base.txt
@@ -407,7 +377,6 @@ text-unidecode==1.3
 typing-extensions==4.12.2
     # via
     #   -r requirements/base.txt
-    #   anyio
     #   edx-opaque-keys
 uritemplate==4.1.1
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
-anyio==4.8.0
-    # via
-    #   -r requirements/test.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r requirements/test.txt
@@ -21,7 +17,6 @@ astroid==3.3.8
 attrs==24.3.0
     # via
     #   -r requirements/test.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
@@ -32,13 +27,10 @@ avro==1.12.0
 cachetools==5.5.0
     # via
     #   -r requirements/test.txt
-    #   confluent-kafka
     #   tox
 certifi==2024.12.14
     # via
     #   -r requirements/test.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -73,8 +65,10 @@ colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-confluent-kafka[avro,schema-registry]==2.7.0
-    # via -r requirements/test.txt
+confluent-kafka[avro,schema-registry]==2.6.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 coverage[toml]==7.6.10
     # via
     #   -r requirements/test.txt
@@ -259,23 +253,9 @@ filelock==3.16.1
     #   virtualenv
 getsmarter-api-clients==0.6.1
     # via -r requirements/test.txt
-h11==0.14.0
-    # via
-    #   -r requirements/test.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r requirements/test.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r requirements/test.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r requirements/test.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -401,7 +381,7 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.19.0
+pygments==2.19.1
     # via
     #   readme-renderer
     #   rich
@@ -541,11 +521,6 @@ six==1.17.0
     #   edx-lint
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r requirements/test.txt
-    #   anyio
-    #   httpx
 snowballstemmer==2.2.0
     # via pydocstyle
 social-auth-app-django==5.4.2
@@ -582,7 +557,6 @@ twine==6.0.1
 typing-extensions==4.12.2
     # via
     #   -r requirements/test.txt
-    #   anyio
     #   django-test-migrations
     #   edx-opaque-keys
     #   faker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
-anyio==4.8.0
-    # via
-    #   -r requirements/base.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r requirements/base.txt
@@ -20,7 +16,6 @@ astroid==3.3.8
 attrs==24.3.0
     # via
     #   -r requirements/base.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
@@ -29,15 +24,10 @@ avro==1.12.0
     #   -r requirements/base.txt
     #   confluent-kafka
 cachetools==5.5.0
-    # via
-    #   -r requirements/base.txt
-    #   confluent-kafka
-    #   tox
+    # via tox
 certifi==2024.12.14
     # via
     #   -r requirements/base.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -67,8 +57,10 @@ code-annotations==2.1.0
     #   edx-toggles
 colorama==0.4.6
     # via tox
-confluent-kafka[avro,schema-registry]==2.7.0
-    # via -r requirements/base.txt
+confluent-kafka[avro,schema-registry]==2.6.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 coverage[toml]==7.6.10
     # via
     #   -r requirements/test.in
@@ -241,23 +233,9 @@ filelock==3.16.1
     #   virtualenv
 getsmarter-api-clients==0.6.1
     # via -r requirements/base.txt
-h11==0.14.0
-    # via
-    #   -r requirements/base.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r requirements/base.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r requirements/base.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r requirements/base.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -458,11 +436,6 @@ six==1.17.0
     #   edx-lint
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r requirements/base.txt
-    #   anyio
-    #   httpx
 social-auth-app-django==5.4.2
     # via
     #   -r requirements/base.txt
@@ -493,7 +466,6 @@ tox==4.23.2
 typing-extensions==4.12.2
     # via
     #   -r requirements/base.txt
-    #   anyio
     #   django-test-migrations
     #   edx-opaque-keys
     #   faker

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -4,11 +4,6 @@
 #
 #    make upgrade
 #
-anyio==4.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r requirements/quality.txt
@@ -25,7 +20,6 @@ attrs==24.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
@@ -38,14 +32,11 @@ cachetools==5.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   confluent-kafka
     #   tox
 certifi==2024.12.14
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -87,7 +78,7 @@ colorama==0.4.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   tox
-confluent-kafka[avro,schema-registry]==2.7.0
+confluent-kafka[avro,schema-registry]==2.6.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -328,27 +319,10 @@ getsmarter-api-clients==0.6.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-h11==0.14.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -515,7 +489,7 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.19.0
+pygments==2.19.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -696,12 +670,6 @@ six==1.17.0
     #   edx-lint
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   anyio
-    #   httpx
 snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
@@ -749,7 +717,6 @@ typing-extensions==4.12.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   anyio
     #   django-test-migrations
     #   edx-opaque-keys
     #   faker


### PR DESCRIPTION
### Description
Pins confluent-kafka < 2.7, since we're experiencing increased CPU usage in stage and prod with 2.7.0 installed.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
