### PR TITLE
docs: fix typo in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ in this repo and we'll *produce* a ping event::
 If this event was successfully produced, you'll see a log message that says
 ``Message delivered to Kafka event bus: topic=dev-events-testing``.
 You should also now see the ``dev-events-testing`` topic available in your local confluent control center,
-and even the test events that are being published to the topic.
+in addition to the test events that are being published to the topic.
 
 Deploying
 =========


### PR DESCRIPTION
Minor docs change to force a new deployment.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
