### PR TITLE
test: add local dev container for consuming event-bus events

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,31 @@ services:
     volumes:
       - .:/edx/app/enterprise-subsidy
       - ../src:/edx/src
-
     command: bash -c 'while true; do python /edx/app/enterprise-subsidy/manage.py runserver 0.0.0.0:18280; sleep 2; done'
     environment:
       DJANGO_SETTINGS_MODULE: enterprise_subsidy.settings.devstack
       ENABLE_DJANGO_TOOLBAR: 1
     ports:
-      - "18280:18280" # TODO: change this to your port
+      - "18280:18280"
+    networks:
+      - devstack_default
+    stdin_open: true
+    tty: true
+    depends_on:
+      - mysql80
+      - memcache
+
+  consume_learner_credit_course_enrollment_lifecycle:
+    image: edxops/enterprise-subsidy-dev
+    container_name: enterprise-subsidy.consume_learner_credit_course_enrollment_lifecycle
+    volumes:
+      - .:/edx/app/enterprise-subsidy
+      - ../src:/edx/src
+    command: bash -c 'while true; do python /edx/app/enterprise-subsidy/manage.py consume_events -t learner-credit-course-enrollment-lifecycle -g enterprise_subsidy_dev; sleep 2; done'
+    environment:
+      DJANGO_SETTINGS_MODULE: enterprise_subsidy.settings.devstack
+    ports:
+      - "18281:18281"
     networks:
       - devstack_default
     stdin_open: true


### PR DESCRIPTION
Launching the new container:
```
(enterprise-subsidy) ubuntu@ip-10-13-20-242:~/edx-repos/enterprise-subsidy$ make dev.up
docker-compose -f /home/ubuntu/edx-repos/devstack/docker-compose.yml up -d redis
[+] Running 1/0
 ✔ Container edx.devstack.redis  Running                                                                                                                                                                                        0.0s 
docker-compose up -d
[+] Running 4/4
 ✔ Container enterprise-subsidy.memcache                                            Running                                                                                                                                     0.0s 
 ✔ Container enterprise-subsidy.mysql80                                             Running                                                                                                                                     0.0s 
 ✔ Container enterprise-subsidy.consume_learner_credit_course_enrollment_lifecycle  Started                                                                                                                                     0.3s 
 ✔ Container enterprise-subsidy.app                                                 Running                                                                                                                                     0.0s 
```
Checking that the container is running and 1) started, 2) consumed an event, and 3) produced a new event:
```
(enterprise-subsidy) ubuntu@ip-10-13-20-242:~/edx-repos/enterprise-subsidy$ make consume_learner_credit_course_enrollment_lifecycle-logs
docker-compose logs -f --tail=500 consume_learner_credit_course_enrollment_lifecycle
enterprise-subsidy.consume_learner_credit_course_enrollment_lifecycle  | 2025-01-09 19:21:04,807 INFO 7 [edx_event_bus_kafka.internal.consumer] [user None] [ip None] [request_id None] consumer.py:284 - Running consumer for {'full_topic': 'dev-learner-credit-course-enrollment-lifecycle', 'consumer_group': 'learner_credit_course_enrollment_lifecycle_dev'}
...
enterprise-subsidy.consume_learner_credit_course_enrollment_lifecycle  | 2025-01-09 19:26:14,819 INFO 7 [edx_event_bus_kafka.internal.consumer] [user None] [ip None] [request_id None] consumer.py:513 - Message received from Kafka: topic=dev-learner-credit-course-enrollment-lifecycle, partition=0, offset=3, message_id=97848778-cebf-11ef-ac26-0242ac120013, key=b'\x00\x00\x00\x00\x01H31f0cc88-1daf-4d28-b862-70367a70838a', event_timestamp_ms=1736450774790
...
[edx_event_bus_kafka.internal.producer] [user None] [ip None] [request_id None] producer.py:244 - Message delivered to Kafka event bus: topic=dev-enterprise-subsidies-transaction-lifecycle, partition=0, offset=21, message_id=97a1cd4c-cebf-11ef-a6d5-0242ac120020, key=b'\x00\x00\x00\x00\x01Heec30573-1aa7-4a0f-abff-31c7e5873ac8'

```