### PR TITLE
fix: coerce CourseLocator to str also when checking refundability given a course

### DIFF
--- a/enterprise_subsidy/apps/transaction/tests/test_utils.py
+++ b/enterprise_subsidy/apps/transaction/tests/test_utils.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import ddt
 from django.test import TestCase
+from opaque_keys.edx.locator import CourseLocator
 from pytz import UTC
 
 from enterprise_subsidy.apps.transaction.signals.handlers import unenrollment_can_be_refunded
@@ -47,7 +48,7 @@ class TransactionUtilsTestCase(TestCase):
         },
     )
     @ddt.unpack
-    def test_unenrollment_can_be_refunded(
+    def test_unenrollment_can_be_refunded_courserun(
         self,
         enterprise_enrollment_created_at,
         course_start_date,
@@ -66,6 +67,68 @@ class TransactionUtilsTestCase(TestCase):
         test_enterprise_course_enrollment = {
             "created": enterprise_enrollment_created_at,
             "unenrolled_at": unenrolled_at,
+        }
+        assert unenrollment_can_be_refunded(
+            test_content_metadata,
+            test_enterprise_course_enrollment,
+        ) == expected_refundable
+
+    @ddt.data(
+        # ALMOST non-refundable due to enterprise_enrollment_created_at.
+        {
+            "enterprise_enrollment_created_at": datetime(2020, 1, 10, tzinfo=UTC),
+            "course_start_date": datetime(2020, 1, 1, tzinfo=UTC),
+            "unenrolled_at": datetime(2020, 1, 23, tzinfo=UTC),
+            "expected_refundable": True,
+        },
+        # Non-refundable due to enterprise_enrollment_created_at.
+        {
+            "enterprise_enrollment_created_at": datetime(2020, 1, 10, tzinfo=UTC),
+            "course_start_date": datetime(2020, 1, 1, tzinfo=UTC),
+            "unenrolled_at": datetime(2020, 1, 24, tzinfo=UTC),
+            "expected_refundable": False,
+        },
+        # ALMOST non-refundable due to course_start_date.
+        {
+            "enterprise_enrollment_created_at": datetime(2020, 1, 1, tzinfo=UTC),
+            "course_start_date": datetime(2020, 1, 10, tzinfo=UTC),
+            "unenrolled_at": datetime(2020, 1, 23, tzinfo=UTC),
+            "expected_refundable": True,
+        },
+        # Non-refundable due to course_start_date.
+        {
+            "enterprise_enrollment_created_at": datetime(2020, 1, 1, tzinfo=UTC),
+            "course_start_date": datetime(2020, 1, 10, tzinfo=UTC),
+            "unenrolled_at": datetime(2020, 1, 24, tzinfo=UTC),
+            "expected_refundable": False,
+        },
+    )
+    @ddt.unpack
+    def test_unenrollment_can_be_refunded_course(
+        self,
+        enterprise_enrollment_created_at,
+        course_start_date,
+        unenrolled_at,
+        expected_refundable,
+    ):
+        """
+        Make sure the following forumla is respected:
+
+        MAX(enterprise_enrollment_created_at, course_start_date) + 14 days > unenrolled_at
+        """
+        test_content_metadata = {
+            "content_type": "course",
+            "course_runs": [
+                {
+                    "key": "course-v1:bin+bar+baz",
+                    "start": course_start_date.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                },
+            ],
+        }
+        test_enterprise_course_enrollment = {
+            "created": enterprise_enrollment_created_at,
+            "unenrolled_at": unenrolled_at,
+            "course_id": CourseLocator("bin", "bar", "baz", None, None),
         }
         assert unenrollment_can_be_refunded(
             test_content_metadata,

--- a/enterprise_subsidy/apps/transaction/utils.py
+++ b/enterprise_subsidy/apps/transaction/utils.py
@@ -63,12 +63,11 @@ def unenrollment_can_be_refunded(
       enterprise_course_enrollment: (dict):
         Serialized ECE object. If the caller has an instance of
         openedx_events.enterprise.data.EnterpriseCourseEnrollment, coerce to
-        data object first:
-          ece_record.__dict__
+        data object first: `ece_record.__dict__`
 
     """
     # Retrieve the course start date from the content metadata
-    enrollment_course_run_key = enterprise_course_enrollment.get("course_id")
+    enrollment_course_run_key = str(enterprise_course_enrollment.get("course_id"))
     course_start_date = None
     if content_metadata.get('content_type') == 'courserun':
         course_start_date = content_metadata.get('start')


### PR DESCRIPTION
In all of our current code that I'm aware of, we only ever pass a course run to unenrollment_can_be_refunded(), but I left a bug in the case where we pass a course.  I'm not completely sure if we need to support this branch anymore, but as long as its there we shouldn't leave it broken.