### PR TITLE
chore: Allow logging format to be overridden

### DIFF
--- a/enterprise_subsidy/settings/base.py
+++ b/enterprise_subsidy/settings/base.py
@@ -352,8 +352,11 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
 PLATFORM_NAME = 'Your Platform Name Here'
 # END OPENEDX-SPECIFIC CONFIGURATION
 
+# Override the default logging format string (default defined within utils.py).
+LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", None)
+
 # Set up logging for development use (logging to stdout)
-LOGGING = get_logger_config(debug=DEBUG)
+LOGGING = get_logger_config(debug=DEBUG, format_string=LOGGING_FORMAT_STRING)
 
 
 # Application settings

--- a/enterprise_subsidy/settings/local.py
+++ b/enterprise_subsidy/settings/local.py
@@ -64,7 +64,7 @@ JWT_AUTH.update({
 
 ENABLE_AUTO_AUTH = True
 
-LOGGING = get_logger_config(debug=DEBUG)
+LOGGING = get_logger_config(debug=DEBUG, format_string=LOGGING_FORMAT_STRING)
 
 # Shell plus
 # https://django-extensions.readthedocs.io/en/latest/shell_plus.html#interactive-python-shells

--- a/enterprise_subsidy/settings/production.py
+++ b/enterprise_subsidy/settings/production.py
@@ -18,8 +18,6 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 ALLOWED_HOSTS = ['*']
 
-LOGGING = get_logger_config()
-
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
 DICT_UPDATE_KEYS = ('JWT_AUTH',)
@@ -49,6 +47,9 @@ if 'EDX_ENTERPRISE_SUBSIDY_CFG' in environ:
         # of Django settings.
         vars().update(FILE_STORAGE_BACKEND)
         vars().update(MEDIA_STORAGE_BACKEND)
+
+# Must be generated after loading config YAML because LOGGING_FORMAT_STRING might be overridden.
+LOGGING = get_logger_config(format_string=LOGGING_FORMAT_STRING)
 
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),

--- a/enterprise_subsidy/settings/utils.py
+++ b/enterprise_subsidy/settings/utils.py
@@ -14,12 +14,23 @@ def get_env_setting(setting):
         raise ImproperlyConfigured(error_msg)
 
 
-def get_logger_config(logging_env="no_env",
-                      debug=False,
-                      service_variant='enterprise-subsidy'):
+def get_logger_config(
+    logging_env: str = "no_env",
+    debug: bool = False,
+    service_variant: str = 'enterprise-subsidy',
+    format_string: str = None,
+):
     """
-    Return the appropriate logging config dictionary. You should assign the
-    result of this to the LOGGING var in your settings.
+    Return the appropriate logging config dictionary, to be assigned to the LOGGING var in settings.
+
+    Arguments:
+        logging_env (str): Environment name.
+        debug (bool): Debug logging enabled.
+        service_variant (str): Name of the service.
+        format_string (str): Override format string for your logfiles.
+
+    Returns:
+        dict(string): Returns a dictionary of config values
     """
     hostname = platform.node().split(".")[0]
     syslog_format = (
@@ -34,14 +45,18 @@ def get_logger_config(logging_env="no_env",
 
     handlers = ['console']
 
+    standard_format = format_string or (
+        '%(asctime)s %(levelname)s %(process)d [%(name)s] '
+        '[user %(userid)s] [ip %(remoteip)s] [request_id %(request_id)s] '
+        '%(filename)s:%(lineno)d - %(message)s'
+    )
+
     logger_config = {
         'version': 1,
         'disable_existing_loggers': False,
         'formatters': {
             'standard': {
-                'format': '%(asctime)s %(levelname)s %(process)d '
-                          '[%(name)s] [user %(userid)s] [ip %(remoteip)s] [request_id %(request_id)s] '
-                          '%(filename)s:%(lineno)d - %(message)s',
+                'format': standard_format,
             },
             'syslog_format': {'format': syslog_format},
             'raw': {'format': '%(message)s'},


### PR DESCRIPTION
Allow logging format to be overridden via LOGGING_FORMAT_STRING.

ENT-10092