### PR TITLE
fix: make external unenrollment insensitive to refundability

### DIFF
--- a/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py
+++ b/enterprise_subsidy/apps/transaction/management/commands/write_reversals_from_enterprise_unenrollments.py
@@ -3,15 +3,13 @@ Management command to fetch enterprise enrollment objects that have been unenrol
 Transaction Reversals where appropriate.
 """
 import logging
+from uuid import UUID
 
 from django.contrib import auth
 from django.core.management.base import BaseCommand
-from openedx_ledger.models import Transaction, TransactionStateChoices
 
 from enterprise_subsidy.apps.api_client.enterprise import EnterpriseApiClient
-from enterprise_subsidy.apps.content_metadata.api import ContentMetadataApi
-from enterprise_subsidy.apps.transaction.api import cancel_transaction_external_fulfillment, reverse_transaction
-from enterprise_subsidy.apps.transaction.utils import unenrollment_can_be_refunded
+from enterprise_subsidy.apps.transaction.signals.handlers import shared_handle_lc_enrollment_revoked
 
 logger = logging.getLogger(__name__)
 User = auth.get_user_model()
@@ -44,94 +42,20 @@ class Command(BaseCommand):
             ),
         )
 
-    def handle_reversing_enterprise_course_unenrollment(self, unenrollment):
+    def handle_lc_enrollment_revoked(self, unenrollment) -> int:
         """
         Helper method to determine refund eligibility of unenrollments and generating reversals for enterprise course
         fulfillments.
 
         Returns 0 if no reversal was written, 1 if a reversal was written.
         """
-        fulfillment_uuid = unenrollment.get("uuid")
-        enterprise_course_enrollment = unenrollment.get("enterprise_course_enrollment")
-        enrollment_course_run_key = enterprise_course_enrollment.get("course_id")
-        enrollment_unenrolled_at = enterprise_course_enrollment.get("unenrolled_at")
-
-        # Look for a transaction related to the unenrollment
-        related_transaction = Transaction.objects.filter(
-            uuid=unenrollment.get('transaction_id')
-        ).first()
-        if not related_transaction:
-            logger.info(
-                f"{self.dry_run_prefix}No Subsidy Transaction found for enterprise fulfillment: {fulfillment_uuid}"
-            )
-            return 0
-        # Fail early if the transaction is not committed, even though reverse_full_transaction()
-        # would throw an exception later anyway.
-        if related_transaction.state != TransactionStateChoices.COMMITTED:
-            logger.info(
-                f"{self.dry_run_prefix}Transaction: {related_transaction} is not in a committed state. "
-                f"Skipping Reversal creation."
-            )
-            return 0
-
-        # Look for a Reversal related to the unenrollment
-        existing_reversal = related_transaction.get_reversal()
-        if existing_reversal:
-            logger.info(
-                f"{self.dry_run_prefix}Found existing Reversal: {existing_reversal} for enterprise fulfillment: "
-                f"{fulfillment_uuid}. Skipping Reversal creation for Transaction: {related_transaction}."
-            )
-            return 0
-
-        # Continue on if no reversal found
-        logger.info(
-            f"{self.dry_run_prefix}No existing Reversal found for enterprise fulfillment: {fulfillment_uuid}. "
-            f"Writing Reversal for Transaction: {related_transaction}."
+        reversal_written = shared_handle_lc_enrollment_revoked(
+            fulfillment_uuid=UUID(unenrollment.get("uuid")),
+            transaction_uuid=UUID(unenrollment.get("transaction_id")),
+            enterprise_course_enrollment=unenrollment.get("enterprise_course_enrollment"),
+            dry_run=self.dry_run,
         )
-
-        # Memoize the content metadata for the course run fetched from the enterprise catalog
-        if not self.fetched_content_metadata.get(enrollment_course_run_key):
-            content_metadata = ContentMetadataApi.get_content_metadata(
-                enrollment_course_run_key,
-            )
-            self.fetched_content_metadata[enrollment_course_run_key] = content_metadata
-        else:
-            content_metadata = self.fetched_content_metadata.get(enrollment_course_run_key)
-
-        # Check if the OCM unenrollment is refundable
-        if not unenrollment_can_be_refunded(
-            content_metadata, enterprise_course_enrollment, related_transaction,
-        ):
-            logger.info(
-                f"{self.dry_run_prefix}Unenrollment from course: {enrollment_course_run_key} by user: "
-                f"{enterprise_course_enrollment.get('enterprise_customer_user')} is not refundable. "
-                f"Related transaction {related_transaction.uuid}."
-            )
-            return 0
-
-        logger.info(
-            f"{self.dry_run_prefix}Course run: {enrollment_course_run_key} is refundable for enterprise "
-            f"customer user: {enterprise_course_enrollment.get('enterprise_customer_user')}. Writing "
-            f"Reversal record for related transaction {related_transaction.uuid}."
-        )
-
-        if not self.dry_run:
-            successfully_canceled = cancel_transaction_external_fulfillment(related_transaction)
-            if successfully_canceled:
-                reverse_transaction(related_transaction, unenroll_time=enrollment_unenrolled_at)
-                return 1
-            else:
-                logger.warning(
-                    'Could not cancel external fulfillment for transaction %s, no reversal written',
-                    related_transaction.uuid,
-                )
-                return 0
-        else:
-            logger.info(
-                f"{self.dry_run_prefix}Would have written Reversal record for enterprise fulfillment: "
-                f"{fulfillment_uuid}. Transaction: {related_transaction}."
-            )
-            return 0
+        return 1 if reversal_written else 0
 
     def handle(self, *args, **options):
         """
@@ -154,7 +78,7 @@ class Command(BaseCommand):
 
         reversals_processed = 0
         for unenrollment in recent_unenrollments:
-            reversals_processed += self.handle_reversing_enterprise_course_unenrollment(unenrollment)
+            reversals_processed += self.handle_lc_enrollment_revoked(unenrollment)
 
         logger.info(
             f"{self.dry_run_prefix}Completed writing {reversals_processed} Transaction Reversals from recent "

--- a/enterprise_subsidy/apps/transaction/utils.py
+++ b/enterprise_subsidy/apps/transaction/utils.py
@@ -3,18 +3,22 @@ Utility functions used in the implementation of subsidy Transactions.
 """
 import logging
 from datetime import datetime, timedelta
+from uuid import UUID
 
 from django.db.models import Q
 
 logger = logging.getLogger(__name__)
 
 
-def generate_transaction_reversal_idempotency_key(fulfillment_uuid, enrollment_unenrolled_at):
+def generate_transaction_reversal_idempotency_key(
+    fulfillment_uuid: UUID,
+    enrollment_unenrolled_at: datetime,
+) -> str:
     """
     Generates a unique idempotency key for a transaction reversal using the fulfillment uuid and time at which the
     unenrollment occurred.
     """
-    return f'unenrollment-reversal-{fulfillment_uuid}-{enrollment_unenrolled_at}'
+    return f'unenrollment-reversal-{fulfillment_uuid}-{enrollment_unenrolled_at.isoformat()}'
 
 
 def batch_by_pk(ModelClass, extra_filter=Q(), batch_size=10000):
@@ -65,9 +69,9 @@ def unenrollment_can_be_refunded(
         Serialized ECE object. If the caller has an instance of
         openedx_events.enterprise.data.EnterpriseCourseEnrollment, coerce to
         data object first: `ece_record.__dict__`
-    last_committed_transaction (Transaction): The last committed, non-reversed transaction
-        associated with this enrollment. It is the responsiblity of the caller to ensure
-        that this Transaction is committed and not reversed.
+      last_committed_transaction (Transaction): The last committed, non-reversed transaction
+          associated with this enrollment. It is the responsiblity of the caller to ensure
+          that this Transaction is committed and not reversed.
 
     """
     # Retrieve the course start date from the content metadata

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -25,6 +25,7 @@ mysqlclient
 openedx-events
 openedx-ledger
 pymemcache
+python-dateutil
 pytz
 rules
 getsmarter-api-clients

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -243,6 +243,8 @@ pymongo==4.12.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
+python-dateutil==2.9.0.post0
+    # via -r requirements/base.in
 python-slugify==8.0.4
     # via code-annotations
 python3-openid==3.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -518,6 +518,8 @@ pytest-cov==6.1.1
     # via -r requirements/validation.txt
 pytest-django==4.11.1
     # via -r requirements/validation.txt
+python-dateutil==2.9.0.post0
+    # via -r requirements/validation.txt
 python-slugify==8.0.4
     # via
     #   -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -487,6 +487,8 @@ pytest-cov==6.1.1
     # via -r requirements/test.txt
 pytest-django==4.11.1
     # via -r requirements/test.txt
+python-dateutil==2.9.0.post0
+    # via -r requirements/test.txt
 python-slugify==8.0.4
     # via
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -315,6 +315,8 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
+python-dateutil==2.9.0.post0
+    # via -r requirements/base.txt
 python-memcached==1.62
     # via -r requirements/production.in
 python-slugify==8.0.4

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -461,6 +461,8 @@ pytest-cov==6.1.1
     # via -r requirements/test.txt
 pytest-django==4.11.1
     # via -r requirements/test.txt
+python-dateutil==2.9.0.post0
+    # via -r requirements/test.txt
 python-slugify==8.0.4
     # via
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -392,6 +392,8 @@ pytest-cov==6.1.1
     # via -r requirements/test.in
 pytest-django==4.11.1
     # via -r requirements/test.in
+python-dateutil==2.9.0.post0
+    # via -r requirements/base.txt
 python-slugify==8.0.4
     # via
     #   -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -592,6 +592,10 @@ pytest-django==4.11.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+python-dateutil==2.9.0.post0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 python-slugify==8.0.4
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
Cancel external fulfillments when the internal one was canceled, regardless of whether the money can be refunded.

Also, refactor the code to make it more DRY across signal handlers and cron-invoked management commands.

ENT-10284