### PR TITLE
chore: upgrade requirements to pull in latest getsmarter-api-clients (0.6.2)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 click==8.1.8
     # via
@@ -41,7 +41,7 @@ code-annotations==2.3.0
     # via edx-toggles
 confluent-kafka[avro,schema-registry]==2.10.0
     # via -r requirements/base.in
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   authlib
     #   pyjwt
@@ -173,7 +173,7 @@ fastavro==1.10.0
     # via
     #   confluent-kafka
     #   openedx-events
-getsmarter-api-clients==0.6.1
+getsmarter-api-clients==0.6.2
     # via -r requirements/base.in
 h11==0.16.0
     # via httpcore
@@ -206,14 +206,14 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/base.in
     #   openedx-ledger
-newrelic==10.10.0
+newrelic==10.11.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==10.0.0
+openedx-events==10.1.0
     # via
     #   -r requirements/base.in
     #   edx-event-bus-kafka
@@ -239,7 +239,7 @@ pyjwt[crypto]==2.10.1
     #   social-auth-core
 pymemcache==4.0.0
     # via -r requirements/base.in
-pymongo==4.12.0
+pymongo==4.12.1
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
@@ -259,7 +259,7 @@ pyyaml==6.0.2
     #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
-redis==5.2.1
+redis==6.0.0
     # via openedx-ledger
 referencing==0.36.2
     # via
@@ -296,7 +296,7 @@ sniffio==1.3.1
     # via anyio
 social-auth-app-django==5.4.3
     # via edx-auth-backends
-social-auth-core==4.6.0
+social-auth-core==4.6.1
     # via
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -30,5 +30,5 @@ pyproject-api==1.9.0
     # via tox
 tox==4.25.0
     # via -r requirements/ci.in
-virtualenv==20.30.0
+virtualenv==20.31.1
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -3,6 +3,11 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -58,7 +58,7 @@ chardet==5.2.0
     #   -r requirements/validation.txt
     #   diff-cover
     #   tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/validation.txt
     #   requests
@@ -90,7 +90,7 @@ coverage[toml]==7.8.0
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   -r requirements/validation.txt
     #   authlib
@@ -154,7 +154,7 @@ django-crum==0.7.9
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
-django-debug-toolbar==5.1.0
+django-debug-toolbar==5.2.0
     # via -r requirements/dev.in
 django-dynamic-fixture==4.0.1
     # via -r requirements/validation.txt
@@ -243,7 +243,7 @@ edx-drf-extensions==10.6.0
     #   edx-rbac
 edx-event-bus-kafka==6.1.0
     # via -r requirements/validation.txt
-edx-i18n-tools==1.8.0
+edx-i18n-tools==1.9.0
     # via -r requirements/dev.in
 edx-lint==5.6.0
     # via -r requirements/validation.txt
@@ -279,7 +279,7 @@ filelock==3.18.0
     #   -r requirements/validation.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.6.1
+getsmarter-api-clients==0.6.2
     # via -r requirements/validation.txt
 h11==0.16.0
     # via
@@ -387,7 +387,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
-newrelic==10.10.0
+newrelic==10.11.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -401,7 +401,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==10.0.0
+openedx-events==10.1.0
     # via
     #   -r requirements/validation.txt
     #   edx-event-bus-kafka
@@ -470,7 +470,7 @@ pyjwt[crypto]==2.10.1
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==3.3.6
+pylint==3.3.7
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -492,7 +492,7 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/validation.txt
-pymongo==4.12.0
+pymongo==4.12.1
     # via
     #   -r requirements/validation.txt
     #   edx-opaque-keys
@@ -545,7 +545,7 @@ readme-renderer==44.0
     # via
     #   -r requirements/validation.txt
     #   twine
-redis==5.2.1
+redis==6.0.0
     # via
     #   -r requirements/validation.txt
     #   openedx-ledger
@@ -622,7 +622,7 @@ social-auth-app-django==5.4.3
     # via
     #   -r requirements/validation.txt
     #   edx-auth-backends
-social-auth-core==4.6.0
+social-auth-core==4.6.1
     # via
     #   -r requirements/validation.txt
     #   edx-auth-backends
@@ -672,7 +672,7 @@ urllib3==2.2.3
     #   requests
     #   responses
     #   twine
-virtualenv==20.30.0
+virtualenv==20.31.1
     # via
     #   -r requirements/validation.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -65,7 +65,7 @@ chardet==5.2.0
     # via
     #   -r requirements/test.txt
     #   tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/test.txt
     #   requests
@@ -95,7 +95,7 @@ coverage[toml]==7.8.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   -r requirements/test.txt
     #   authlib
@@ -279,7 +279,7 @@ filelock==3.18.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.6.1
+getsmarter-api-clients==0.6.2
     # via -r requirements/test.txt
 h11==0.16.0
     # via
@@ -367,7 +367,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==10.10.0
+newrelic==10.11.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -379,7 +379,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==10.0.0
+openedx-events==10.1.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
@@ -442,7 +442,7 @@ pyjwt[crypto]==2.10.1
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==3.3.6
+pylint==3.3.7
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -464,7 +464,7 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/test.txt
-pymongo==4.12.0
+pymongo==4.12.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -511,7 +511,7 @@ pyyaml==6.0.2
     #   responses
 readme-renderer==44.0
     # via twine
-redis==5.2.1
+redis==6.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -583,7 +583,7 @@ social-auth-app-django==5.4.3
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.6.0
+social-auth-core==4.6.1
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -657,7 +657,7 @@ urllib3==2.2.3
     #   requests
     #   responses
     #   twine
-virtualenv==20.30.0
+virtualenv==20.31.1
     # via
     #   -r requirements/test.txt
     #   tox

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/enterprise-subsidy/enterprise-subsidy/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==80.0.0
+setuptools==80.3.1
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -43,7 +43,7 @@ cffi==1.17.1
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/base.txt
     #   requests
@@ -58,7 +58,7 @@ code-annotations==2.3.0
     #   edx-toggles
 confluent-kafka[avro,schema-registry]==2.10.0
     # via -r requirements/base.txt
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   -r requirements/base.txt
     #   authlib
@@ -203,7 +203,7 @@ fastavro==1.10.0
     #   -r requirements/base.txt
     #   confluent-kafka
     #   openedx-events
-getsmarter-api-clients==0.6.1
+getsmarter-api-clients==0.6.2
     # via -r requirements/base.txt
 gevent==25.4.2
     # via -r requirements/production.in
@@ -259,7 +259,7 @@ mysqlclient==2.2.7
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   openedx-ledger
-newrelic==10.10.0
+newrelic==10.11.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -269,7 +269,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==10.0.0
+openedx-events==10.1.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -307,7 +307,7 @@ pyjwt[crypto]==2.10.1
     #   social-auth-core
 pymemcache==4.0.0
     # via -r requirements/base.txt
-pymongo==4.12.0
+pymongo==4.12.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -339,7 +339,7 @@ pyyaml==6.0.2
     #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
-redis==5.2.1
+redis==6.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -389,7 +389,7 @@ social-auth-app-django==5.4.3
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.6.0
+social-auth-core==4.6.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -53,7 +53,7 @@ chardet==5.2.0
     # via
     #   -r requirements/test.txt
     #   tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/test.txt
     #   requests
@@ -83,7 +83,7 @@ coverage[toml]==7.8.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   -r requirements/test.txt
     #   authlib
@@ -262,7 +262,7 @@ filelock==3.18.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.6.1
+getsmarter-api-clients==0.6.2
     # via -r requirements/test.txt
 h11==0.16.0
     # via
@@ -348,7 +348,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==10.10.0
+newrelic==10.11.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -360,7 +360,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==10.0.0
+openedx-events==10.1.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
@@ -418,7 +418,7 @@ pyjwt[crypto]==2.10.1
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==3.3.6
+pylint==3.3.7
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -440,7 +440,7 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/test.txt
-pymongo==4.12.0
+pymongo==4.12.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -485,7 +485,7 @@ pyyaml==6.0.2
     #   responses
 readme-renderer==44.0
     # via twine
-redis==5.2.1
+redis==6.0.0
     # via
     #   -r requirements/test.txt
     #   openedx-ledger
@@ -552,7 +552,7 @@ social-auth-app-django==5.4.3
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.6.0
+social-auth-core==4.6.1
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -602,7 +602,7 @@ urllib3==2.2.3
     #   requests
     #   responses
     #   twine
-virtualenv==20.30.0
+virtualenv==20.31.1
     # via
     #   -r requirements/test.txt
     #   tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -50,7 +50,7 @@ cffi==1.17.1
     #   pynacl
 chardet==5.2.0
     # via tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/base.txt
     #   requests
@@ -77,7 +77,7 @@ coverage[toml]==7.8.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   -r requirements/base.txt
     #   authlib
@@ -244,7 +244,7 @@ filelock==3.18.0
     # via
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.6.1
+getsmarter-api-clients==0.6.2
     # via -r requirements/base.txt
 h11==0.16.0
     # via
@@ -301,7 +301,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
-newrelic==10.10.0
+newrelic==10.11.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -311,7 +311,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==10.0.0
+openedx-events==10.1.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -358,7 +358,7 @@ pyjwt[crypto]==2.10.1
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==3.3.6
+pylint==3.3.7
     # via
     #   edx-lint
     #   pylint-celery
@@ -374,7 +374,7 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/base.txt
-pymongo==4.12.0
+pymongo==4.12.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -414,7 +414,7 @@ pyyaml==6.0.2
     #   drf-yasg
     #   edx-django-release-util
     #   responses
-redis==5.2.1
+redis==6.0.0
     # via
     #   -r requirements/base.txt
     #   openedx-ledger
@@ -468,7 +468,7 @@ social-auth-app-django==5.4.3
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.6.0
+social-auth-core==4.6.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -511,7 +511,7 @@ urllib3==2.2.3
     #   -r requirements/base.txt
     #   requests
     #   responses
-virtualenv==20.30.0
+virtualenv==20.31.1
     # via tox
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -63,7 +63,7 @@ chardet==5.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -101,7 +101,7 @@ coverage[toml]==7.8.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -330,7 +330,7 @@ filelock==3.18.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.6.1
+getsmarter-api-clients==0.6.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -449,7 +449,7 @@ mysqlclient==2.2.7
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openedx-ledger
-newrelic==10.10.0
+newrelic==10.11.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -465,7 +465,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==10.0.0
+openedx-events==10.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -535,7 +535,7 @@ pyjwt[crypto]==2.10.1
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==3.3.6
+pylint==3.3.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -563,7 +563,7 @@ pymemcache==4.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-pymongo==4.12.0
+pymongo==4.12.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -622,7 +622,7 @@ readme-renderer==44.0
     # via
     #   -r requirements/quality.txt
     #   twine
-redis==5.2.1
+redis==6.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -711,7 +711,7 @@ social-auth-app-django==5.4.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.6.0
+social-auth-core==4.6.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -771,7 +771,7 @@ urllib3==2.2.3
     #   requests
     #   responses
     #   twine
-virtualenv==20.30.0
+virtualenv==20.31.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description

Runs `make upgrade` to upgrade `getsmarter-api-clients` to the latest version ([0.6.2](https://github.com/edx/getsmarter-api-clients/releases/tag/0.6.2)) to add additional logging of the payload sent to GEAG during allocation.

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
