### PR TITLE
chore: bump getsmarter-api-clients to 0.6.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -173,7 +173,7 @@ fastavro==1.10.0
     # via
     #   confluent-kafka
     #   openedx-events
-getsmarter-api-clients==0.6.2
+getsmarter-api-clients==0.6.3
     # via -r requirements/base.in
 h11==0.16.0
     # via httpcore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -279,7 +279,7 @@ filelock==3.18.0
     #   -r requirements/validation.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.6.2
+getsmarter-api-clients==0.6.3
     # via -r requirements/validation.txt
 h11==0.16.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -279,7 +279,7 @@ filelock==3.18.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.6.2
+getsmarter-api-clients==0.6.3
     # via -r requirements/test.txt
 h11==0.16.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -203,7 +203,7 @@ fastavro==1.10.0
     #   -r requirements/base.txt
     #   confluent-kafka
     #   openedx-events
-getsmarter-api-clients==0.6.2
+getsmarter-api-clients==0.6.3
     # via -r requirements/base.txt
 gevent==25.4.2
     # via -r requirements/production.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -262,7 +262,7 @@ filelock==3.18.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.6.2
+getsmarter-api-clients==0.6.3
     # via -r requirements/test.txt
 h11==0.16.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -244,7 +244,7 @@ filelock==3.18.0
     # via
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.6.2
+getsmarter-api-clients==0.6.3
     # via -r requirements/base.txt
 h11==0.16.0
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -330,7 +330,7 @@ filelock==3.18.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-getsmarter-api-clients==0.6.2
+getsmarter-api-clients==0.6.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description
Bumps `getsmarter-api-clients` to 0.6.3 by running `make upgrade`.

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
