### PR TITLE
fix: create deposit api view less restrictive

### DIFF
--- a/enterprise_subsidy/apps/api/exceptions.py
+++ b/enterprise_subsidy/apps/api/exceptions.py
@@ -17,6 +17,7 @@ class ErrorCodes:
     LEDGER_LOCK_ERROR = 'ledger_lock_error'
     INACTIVE_SUBSIDY_CREATION_ERROR = 'inactive_subsidy_creation_error'
     FULFILLMENT_ERROR = 'fulfillment_error'
+    DEPOSIT_ON_EXPIRED_SUBSIDY_ERROR = 'deposit_on_expired_subsidy'
 
 
 class SubsidyAPIException(APIException):


### PR DESCRIPTION
Allow for the creation of deposits as long as the related subsidy has not yet expired, even if the subsidy/ledger is not yet *active*.
ENT-10615

Testing:
Hit this endpoint on a subsidy that has already expired:
```
curl --location 'http://localhost:18280/api/v2/subsidies/4025047c-609a-4e64-8546-aaddb15af4eb/admin/deposits/' \
--header 'Authorization: JWT [your-jwt]
--header 'Content-Type: application/json' \
--data '{does not actually matter for this test}'
}'
```

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
