### PR TITLE
feat: Add course_run_start_date to api serializers

### DIFF
--- a/enterprise_subsidy/apps/api/v1/serializers.py
+++ b/enterprise_subsidy/apps/api/v1/serializers.py
@@ -144,6 +144,7 @@ class TransactionSerializer(serializers.ModelSerializer):
             "content_key",
             "parent_content_key",
             "content_title",
+            "course_run_start_date",
             "quantity",
             "unit",  # Manually fetch from parent ledger via get_unit().
             "fulfillment_identifier",

--- a/enterprise_subsidy/apps/api/v1/tests/test_views.py
+++ b/enterprise_subsidy/apps/api/v1/tests/test_views.py
@@ -440,13 +440,17 @@ class SubsidyViewSetTests(APITestBase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        created = self.subsidy_1_transaction_1.created.strftime(SERIALIZED_DATE_PATTERN)
+        modified = self.subsidy_1_transaction_1.modified.strftime(SERIALIZED_DATE_PATTERN)
+        course_run_start_date = self.subsidy_1_transaction_1.course_run_start_date.strftime(SERIALIZED_DATE_PATTERN)
+
         expected_existing_transactions = []
         if has_existing_transaction:
             expected_existing_transactions.append({
-                'created': self.subsidy_1_transaction_1.created.strftime(SERIALIZED_DATE_PATTERN),
+                'created': created,
                 'idempotency_key': str(self.subsidy_1_transaction_1.idempotency_key),
                 'metadata': None,
-                'modified': self.subsidy_1_transaction_1.modified.strftime(SERIALIZED_DATE_PATTERN),
+                'modified': modified,
                 'uuid': str(self.subsidy_1_transaction_1_uuid),
                 'fulfillment_identifier': None,
                 'reversal': None,
@@ -459,6 +463,7 @@ class SubsidyViewSetTests(APITestBase):
                 'content_key': self.content_key_1,
                 'parent_content_key': self.parent_content_key_1,
                 'content_title': self.content_title_1,
+                'course_run_start_date': course_run_start_date,
                 'external_reference': [],
                 'transaction_status_api_url': f"{self.transaction_status_api_url}/{self.subsidy_1_transaction_1_uuid}/",
                 'courseware_url': f"http://localhost:2000/course/{self.content_key_1}/home",
@@ -1707,6 +1712,7 @@ class ContentMetadataViewSetTests(APITestBase):
                         "upgrade_deadline": None,
                     },
                 ],
+                "start": "2024-01-01T00:00:00Z",
             }
         ],
         "advertised_course_run_uuid": course_run_uuid,
@@ -1742,6 +1748,7 @@ class ContentMetadataViewSetTests(APITestBase):
                 "uuid": course_run_uuid,
                 "variant_id": "79a95406-a9ac-49b3-a27c-44f3fd06092e",
                 "enrollment_end": "2024-01-01T00:00:00Z",
+                "start": "2024-01-01T00:00:00Z",
             }
         ],
         "advertised_course_run_uuid": course_run_uuid,
@@ -1767,6 +1774,7 @@ class ContentMetadataViewSetTests(APITestBase):
             'expected_mode': 'verified',
             'expected_geag_variant_id': None,
             'expected_enroll_by_date': '2025-01-01T00:00:00Z',
+            'expected_course_run_start_date': '2024-01-01T00:00:00Z',
         },
         {
             'expected_content_title': content_title,
@@ -1781,6 +1789,7 @@ class ContentMetadataViewSetTests(APITestBase):
             # generated randomly using a fair die
             'expected_geag_variant_id': '79a95406-a9ac-49b3-a27c-44f3fd06092e',
             'expected_enroll_by_date': '2024-01-01T00:00:00Z',
+            'expected_course_run_start_date': '2024-01-01T00:00:00Z',
         },
     )
     @ddt.unpack
@@ -1797,6 +1806,7 @@ class ContentMetadataViewSetTests(APITestBase):
         expected_mode,
         expected_geag_variant_id,
         expected_enroll_by_date,
+        expected_course_run_start_date
     ):
         with mock.patch(
             'enterprise_subsidy.apps.api_client.base_oauth.OAuthAPIClient',
@@ -1823,6 +1833,7 @@ class ContentMetadataViewSetTests(APITestBase):
                 'mode': expected_mode,
                 'geag_variant_id': expected_geag_variant_id,
                 'enroll_by_date': expected_enroll_by_date,
+                'course_run_start_date': expected_course_run_start_date,
             }
 
             # Now make a second call to validate that the view-level cache is utilized.
@@ -1845,6 +1856,7 @@ class ContentMetadataViewSetTests(APITestBase):
                 'mode': expected_mode,
                 'geag_variant_id': expected_geag_variant_id,
                 'enroll_by_date': expected_enroll_by_date,
+                'course_run_start_date': expected_course_run_start_date,
             }
             # Validate that, in the first, non-cached request, we call
             # the enterprise catalog endpoint via the client, and that

--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -180,6 +180,7 @@ class ContentMetadataApi:
             'content_key': content_data.get('key'),
             'course_run_uuid': course_run_content.get('uuid'),
             'course_run_key': course_run_content.get('key'),
+            'course_run_start_date': course_run_content.get('start'),
             'source': self.product_source_for_content(content_data),
             'mode': content_mode,
             'content_price': self.price_for_content(content_data, course_run_content),

--- a/enterprise_subsidy/apps/subsidy/models.py
+++ b/enterprise_subsidy/apps/subsidy/models.py
@@ -374,6 +374,7 @@ class Subsidy(TimeStampedModel):
         content_key=None,
         parent_content_key=None,
         content_title=None,
+        course_run_start_date=None,
         subsidy_access_policy_uuid=None,
         **transaction_metadata
     ):
@@ -395,6 +396,7 @@ class Subsidy(TimeStampedModel):
             content_key=content_key,
             parent_content_key=parent_content_key,
             content_title=content_title,
+            course_run_start_date=course_run_start_date,
             subsidy_access_policy_uuid=subsidy_access_policy_uuid,
             **transaction_metadata,
         )
@@ -518,6 +520,7 @@ class Subsidy(TimeStampedModel):
             content_metadata_summary = self.metadata_summary_for_content(content_key)
             content_title = content_metadata_summary.get('content_title')
             parent_content_key = content_metadata_summary.get('content_key')
+            course_run_start_date = content_metadata_summary.get('course_run_start_date')
 
             transaction = self._create_redemption(
                 lms_user_id,
@@ -527,6 +530,7 @@ class Subsidy(TimeStampedModel):
                 subsidy_access_policy_uuid,
                 lms_user_email=lms_user_email,
                 content_title=content_title,
+                course_run_start_date=course_run_start_date,
                 idempotency_key=idempotency_key,
                 metadata=metadata,
             )
@@ -558,6 +562,7 @@ class Subsidy(TimeStampedModel):
             subsidy_access_policy_uuid,
             content_title=None,
             lms_user_email=None,
+            course_run_start_date=None,
             idempotency_key=None,
             metadata=None
     ):
@@ -611,6 +616,7 @@ class Subsidy(TimeStampedModel):
             content_key=content_key,
             parent_content_key=parent_content_key,
             content_title=content_title,
+            course_run_start_date=course_run_start_date,
             lms_user_id=lms_user_id,
             lms_user_email=lms_user_email,
             subsidy_access_policy_uuid=subsidy_access_policy_uuid,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -219,7 +219,7 @@ openedx-events==10.5.0
     #   -r requirements/base.in
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.6.8
+openedx-ledger==1.6.9
     # via -r requirements/base.in
 orjson==3.11.3
     # via confluent-kafka

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -404,7 +404,7 @@ openedx-events==10.5.0
     #   -r requirements/validation.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.6.8
+openedx-ledger==1.6.9
     # via -r requirements/validation.txt
 orjson==3.11.3
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -382,7 +382,7 @@ openedx-events==10.5.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.6.8
+openedx-ledger==1.6.9
     # via -r requirements/test.txt
 orjson==3.11.3
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -272,7 +272,7 @@ openedx-events==10.5.0
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.6.8
+openedx-ledger==1.6.9
     # via -r requirements/base.txt
 orjson==3.11.3
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -363,7 +363,7 @@ openedx-events==10.5.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.6.8
+openedx-ledger==1.6.9
     # via -r requirements/test.txt
 orjson==3.11.3
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -313,7 +313,7 @@ openedx-events==10.5.0
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.6.8
+openedx-ledger==1.6.9
     # via -r requirements/base.txt
 orjson==3.11.3
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -468,7 +468,7 @@ openedx-events==10.5.0
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   openedx-ledger
-openedx-ledger==1.6.8
+openedx-ledger==1.6.9
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description
This adds a course_run_start_date to the API endpoints.

Should only be run once the migration on the Transaction model on https://github.com/openedx/openedx-ledger

Blocked by: https://github.com/openedx/openedx-ledger/pull/183

Ticket [ENT-10827](https://2u-internal.atlassian.net/browse/ENT-10827)

### Testing instructions

Add some, if applicable

### Merge checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
