### PR TITLE
fix: Stop reading geag_variant_id from a deprecated dict

### DIFF
--- a/enterprise_subsidy/apps/content_metadata/api.py
+++ b/enterprise_subsidy/apps/content_metadata/api.py
@@ -132,10 +132,14 @@ class ContentMetadataApi:
         """
         course_run_content = self.get_course_run(content_identifier, content_data)
         variant_id = course_run_content.get('variant_id')
-        # If no variant_id is found, and this is indeed an Exec Ed course, check the deprecated `additional_metadata`.
-        if not variant_id:
-            if additional_metadata := content_data.get('additional_metadata'):
-                variant_id = additional_metadata.get('variant_id')
+        if variant_id:
+            logger.info(f'Found variant_id "{variant_id}" for the requested content "{content_identifier}".')
+        else:
+            # In the past, we pulled the variant_id from additional_metadata, but that
+            # dict has been long deprecated. In fact, we kept that fallback logic for too
+            # long and it bit us really bad. It's much better and safer to just terminally
+            # error if we encounter this scenario again.
+            logger.warning(f'Could NOT find a variant_id for the requested content "{content_identifier}".')
         return variant_id
 
     def enroll_by_date_for_content(self, course_run_data, content_mode):

--- a/enterprise_subsidy/apps/content_metadata/tests/test_api.py
+++ b/enterprise_subsidy/apps/content_metadata/tests/test_api.py
@@ -317,19 +317,19 @@ class ContentMetadataApiTests(TestCase):
             'requested_content_key': courserun_key_2,
             'expected_variant_id': None,
         },
-        # We can remove all the following test cases once we stop using the
+        # We can remove all the following test cases once we stop populating the
         # deprecated ``additional_metadata``.
         {
             'remove_variant_id_from_runs': False,
             'remove_variant_id_from_additional_metadata': False,
             'requested_content_key': course_key,
-            'expected_variant_id': variant_id_2,
+            'expected_variant_id': variant_id_2,  # The variant from the advertised run should be selected.
         },
         {
             'remove_variant_id_from_runs': True,
             'remove_variant_id_from_additional_metadata': False,
             'requested_content_key': course_key,
-            'expected_variant_id': variant_id_2,
+            'expected_variant_id': None,
         },
         {
             'remove_variant_id_from_runs': False,
@@ -341,7 +341,7 @@ class ContentMetadataApiTests(TestCase):
             'remove_variant_id_from_runs': True,
             'remove_variant_id_from_additional_metadata': False,
             'requested_content_key': courserun_key_1,
-            'expected_variant_id': variant_id_2,
+            'expected_variant_id': None,
         },
         {
             'remove_variant_id_from_runs': False,
@@ -353,7 +353,7 @@ class ContentMetadataApiTests(TestCase):
             'remove_variant_id_from_runs': True,
             'remove_variant_id_from_additional_metadata': False,
             'requested_content_key': courserun_key_2,
-            'expected_variant_id': variant_id_2,
+            'expected_variant_id': None,
         },
     )
     @ddt.unpack

--- a/enterprise_subsidy/apps/fulfillment/exceptions.py
+++ b/enterprise_subsidy/apps/fulfillment/exceptions.py
@@ -9,3 +9,7 @@ class FulfillmentException(Exception):
 
 class InvalidFulfillmentMetadataException(FulfillmentException):
     pass
+
+
+class IncompleteContentMetadataException(FulfillmentException):
+    pass


### PR DESCRIPTION
Here is a PR to treat a missing `variant_id` from the run-specific parts of content metadata as fatally fatal during fulfillment.  This removes what was meant to be a TEMPORARY fallback to utilize the now-deprecated `additional_metadata` dict.

An external fulfillment failure will bubble up and revert the Transaction, and the Assignment record, if any, will transition to ERRORED. This is a better outcome because before this PR, we would have happily enrolled Exec Ed learners in the **wrong variant**.

Fixes: https://2u-internal.atlassian.net/browse/ENT-10929